### PR TITLE
Update knative to 1.6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,9 +31,9 @@ jobs:
             sudo microk8s addons repo remove community
           fi
           sudo microk8s addons repo add community .
-          export UNDER_TIME_PRESSURE="True"
+          #export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py
+          sudo -E pytest -s -ra ./tests/test-addons.py::TestAddons::test_knative
           sudo snap remove microk8s --purge
       - name: Running addons tests on strict
         run: |
@@ -45,7 +45,7 @@ jobs:
             sudo microk8s addons repo remove community
           fi
           sudo microk8s addons repo add community .
-          export UNDER_TIME_PRESSURE="True"
+          #export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py
+          sudo -E pytest -s -ra ./tests/test-addons.py::TestAddons::test_knative
           sudo snap remove microk8s --purge

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,9 +31,9 @@ jobs:
             sudo microk8s addons repo remove community
           fi
           sudo microk8s addons repo add community .
-          #export UNDER_TIME_PRESSURE="True"
+          export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py::TestAddons::test_knative
+          sudo -E pytest -s -ra ./tests/test-addons.py
           sudo snap remove microk8s --purge
       - name: Running addons tests on strict
         run: |
@@ -45,7 +45,7 @@ jobs:
             sudo microk8s addons repo remove community
           fi
           sudo microk8s addons repo add community .
-          #export UNDER_TIME_PRESSURE="True"
+          export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          sudo -E pytest -s -ra ./tests/test-addons.py::TestAddons::test_knative
+          sudo -E pytest -s -ra ./tests/test-addons.py
           sudo snap remove microk8s --purge

--- a/addons.yaml
+++ b/addons.yaml
@@ -18,10 +18,11 @@ microk8s-addons:
         - amd64
 
     - name: "knative"
-      description: "The Knative framework on Kubernetes."
-      version: "0.24.0"
-      check_status: "deployment.apps/eventing-webhook"
+      description: "Knative Serverless and Event Driven Applications"
+      version: "1.6.0"
+      check_status: "deployment.apps/knative-operator"
       supported_architectures:
+        - arm64
         - amd64
 
     - name: "fluentd"

--- a/addons/knative/disable
+++ b/addons/knative/disable
@@ -26,10 +26,10 @@ if $KUBECTL get deployment knative-operator -n default; then
     $KUBECTL delete -f https://github.com/knative/operator/releases/download/knative-v$KNATIVE_VERSION/operator.yaml
 fi
 
-run_with_sudo rm -rf "${SNAP_DATA}/bin/kn"
-run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-admin"
-run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-event"
-run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-func"
+run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn"
+run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-admin"
+run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-event"
+run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-func"
 
 
 

--- a/addons/knative/disable
+++ b/addons/knative/disable
@@ -4,25 +4,32 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Disabling Knative"
-
+KNATIVE_VERSION="1.6.0"
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 
-declare -a yamls=("https://github.com/knative/serving/releases/download/v0.24.0/serving-core.yaml"
-                  "https://github.com/knative/net-istio/releases/download/v0.24.0/net-istio.yaml"
-                  "https://github.com/knative/serving/releases/download/v0.24.0/serving-default-domain.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/eventing-core.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/in-memory-channel.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/mt-channel-broker.yaml"
-                  "https://github.com/knative/serving/releases/download/v0.24.0/serving-crds.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/eventing-crds.yaml"
-                 )
 
-# || true is there to handle race conditions in deleting resources
-for yaml in "${yamls[@]}"
-do
-   $KUBECTL delete -f "$yaml" 2>&1 > /dev/null || true
-   sleep 3
-done
+echo "Disabling Knative"
 
-echo "Knative is terminating"
+if $KUBECTL get KnativeServing -n knative-serving knative-serving; then
+    $KUBECTL delete KnativeServing -n knative-serving knative-serving
+fi
+if $KUBECTL get ns knative-serving; then
+    $KUBECTL delete ns knative-serving
+fi
+if $KUBECTL get KnativeEventing -n knative-eventing knative-eventing; then
+    $KUBECTL delete KnativeEventing -n knative-eventing knative-eventing
+fi
+if $KUBECTL get ns knative-eventing; then
+    $KUBECTL delete ns knative-eventing
+fi
+if $KUBECTL get deployment knative-operator -n default; then
+    $KUBECTL delete -f https://github.com/knative/operator/releases/download/knative-v$KNATIVE_VERSION/operator.yaml
+fi
+
+run_with_sudo rm -rf "${SNAP_DATA}/bin/kn"
+run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-admin"
+run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-event"
+run_with_sudo rm -rf "${SNAP_DATA}/bin/kn-func"
+
+
+

--- a/addons/knative/disable
+++ b/addons/knative/disable
@@ -29,7 +29,3 @@ run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn"
 run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-admin"
 run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-event"
 run_with_sudo rm -rf "${SNAP_COMMON}/plugins/kn-func"
-
-
-
-

--- a/addons/knative/enable
+++ b/addons/knative/enable
@@ -4,30 +4,111 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Enabling Knative"
-
-"$SNAP/microk8s-enable.wrapper" istio
-
+KNATIVE_VERSION="1.6.0"
+KNATIVE_FUNC_VERSION="0.25.0"
+KNATIVE_SERVING=true
+KNATIVE_EVENTING=false
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 
-declare -a yamls=("https://github.com/knative/serving/releases/download/v0.24.0/serving-crds.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/eventing-crds.yaml"
-                  "https://github.com/knative/serving/releases/download/v0.24.0/serving-core.yaml"
-                  "https://github.com/knative/net-istio/releases/download/v0.24.0/net-istio.yaml"
-                  "https://github.com/knative/serving/releases/download/v0.24.0/serving-default-domain.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/eventing-core.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/in-memory-channel.yaml"
-                  "https://github.com/knative/eventing/releases/download/v0.24.0/mt-channel-broker.yaml"
-                 )
-
-for yaml in "${yamls[@]}"
+for i in "$@"
 do
-   $KUBECTL apply -f "$yaml"
-   sleep 3
+case $i in
+    --no-serving)
+    KNATIVE_SERVING=false
+    shift # past argument
+    ;;
+    --eventing)
+    KNATIVE_EVENTING=true
+    shift # past argument
+    ;;
+    *)
+          # unknown option
+    ;;
+esac
 done
 
+#requirement
+"$SNAP/microk8s-enable.wrapper" dns
+
+echo "Enabling Knative ${KNATIVE_VERSION}"
+$KUBECTL apply -f https://github.com/knative/operator/releases/download/knative-v$KNATIVE_VERSION/operator.yaml
+
+if [ "$KNATIVE_SERVING" = "true" ]; then
+    echo "Installing Knative Serving ${KNATIVE_VERSION}"
+$KUBECTL apply -f- << EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  ingress:
+    kourier:
+      enabled: true
+  config:
+    network:
+      ingress-class: "kourier.ingress.networking.knative.dev"
+EOF
+fi
+
+if [ "$KNATIVE_EVENTING" = "true" ]; then
+   echo "Installing Knative Eventing ${KNATIVE_VERSION}"
+$KUBECTL apply -f- << EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-eventing
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+EOF
+fi
+
+# Handle Knative CLIs
+if [ ! -f "${SNAP_DATA}/bin/kn" ]; then
+  echo "Fetching Knative CLI version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn"
+  run_with_sudo mkdir -p "$SNAP_DATA/bin"
+  fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${ARCH} "$SNAP_DATA/bin/kn"
+  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn"
+fi
+if [ ! -f "${SNAP_DATA}/bin/kn-admin" ]; then
+  echo "Fetching Knative CLI Admin plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-admin"
+  run_with_sudo mkdir -p "$SNAP_DATA/bin"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${ARCH} "$SNAP_DATA/bin/kn-admin"
+  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-admin"
+fi
+if [ ! -f "${SNAP_DATA}/bin/kn-event" ]; then
+  echo "Fetching Knative CLI Event plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-event"
+  run_with_sudo mkdir -p "$SNAP_DATA/bin"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${ARCH} "$SNAP_DATA/bin/kn-event"
+  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-event"
+fi
+if [ ! -f "${SNAP_DATA}/bin/kn-func" ] && [ "$ARCH" = "amd64" ]; then
+  echo "Fetching Knative Functions plugin version ${KNATIVE_FUNC_VERSION} in $SNAP_DATA/bin/kn-func"
+  run_with_sudo mkdir -p "$SNAP_DATA/bin"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${ARCH} "$SNAP_DATA/bin/kn-func"
+  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-func"
+fi
+
+if [ "$KNATIVE_SERVING" = "true" ]; then
+    echo ""
+    echo ""
+    echo "Enable metalb addon to get a loadbalancer for Knative Serving, for example microk8s enable metallb:10.64.140.43-10.64.140.49"
+    echo ""
+    echo "Configure the domain for Knative services using:"
+    echo "kubectl get svc -n knative-serving kourier"
+    echo "kubectl patch configmap -n knative-serving config-domain -p '{"data": {"EXTERNAL-IP.sslip.io": ""}}'"
+    echo ""
+fi
 echo ""
 echo ""
-echo "Visit https://knative.dev/docs/admin/ to customize which broker channel"
-echo "implementation is used and to specify which configurations are used for which namespaces."
+echo "Visit https://knative.dev/docs/install/operator/knative-with-operators/ for more Knative customizations"
 echo ""

--- a/addons/knative/enable
+++ b/addons/knative/enable
@@ -76,25 +76,25 @@ fi
 if [ ! -f "${SNAP_DATA}/bin/kn" ]; then
   echo "Fetching Knative CLI version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${ARCH} "$SNAP_DATA/bin/kn"
+  fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn"
 fi
 if [ ! -f "${SNAP_DATA}/bin/kn-admin" ]; then
   echo "Fetching Knative CLI Admin plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-admin"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${ARCH} "$SNAP_DATA/bin/kn-admin"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-admin"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-admin"
 fi
 if [ ! -f "${SNAP_DATA}/bin/kn-event" ]; then
   echo "Fetching Knative CLI Event plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-event"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${ARCH} "$SNAP_DATA/bin/kn-event"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-event"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-event"
 fi
-if [ ! -f "${SNAP_DATA}/bin/kn-func" ] && [ "$ARCH" = "amd64" ]; then
+if [ ! -f "${SNAP_DATA}/bin/kn-func" ] && [ "${SNAP_ARCH}" = "amd64" ]; then
   echo "Fetching Knative Functions plugin version ${KNATIVE_FUNC_VERSION} in $SNAP_DATA/bin/kn-func"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${ARCH} "$SNAP_DATA/bin/kn-func"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${SNAP_ARCH} "$SNAP_DATA/bin/kn-func"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-func"
 fi
 

--- a/addons/knative/enable
+++ b/addons/knative/enable
@@ -73,25 +73,25 @@ EOF
 fi
 
 # Handle Knative CLIs
-if [ ! -f "${SNAP_DATA}/bin/kn" ]; then
+if [ ! -f "${SNAP_COMMON}/plugins/kn" ]; then
   echo "Fetching Knative CLI version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn"
 fi
-if [ ! -f "${SNAP_DATA}/bin/kn-admin" ]; then
+if [ ! -f "${SNAP_COMMON}/plugins/kn-admin" ]; then
   echo "Fetching Knative CLI Admin plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-admin"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-admin"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-admin"
 fi
-if [ ! -f "${SNAP_DATA}/bin/kn-event" ]; then
+if [ ! -f "${SNAP_COMMON}/plugins/kn-event" ]; then
   echo "Fetching Knative CLI Event plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-event"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-event"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-event"
 fi
-if [ ! -f "${SNAP_DATA}/bin/kn-func" ] && [ "${SNAP_ARCH}" = "amd64" ]; then
+if [ ! -f "${SNAP_COMMON}/plugins/kn-func" ] && [ "${SNAP_ARCH}" = "amd64" ]; then
   echo "Fetching Knative Functions plugin version ${KNATIVE_FUNC_VERSION} in $SNAP_DATA/bin/kn-func"
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${SNAP_ARCH} "$SNAP_DATA/bin/kn-func"
@@ -109,6 +109,8 @@ if [ "$KNATIVE_SERVING" = "true" ]; then
     echo ""
 fi
 echo ""
+echo ""
+echo "To be able to use 'microk8s kn <plugin>' such as 'func' add to env PATH the value ${SNAP_COMMON}/plugins"
 echo ""
 echo "Visit https://knative.dev/docs/install/operator/knative-with-operators/ for more Knative customizations"
 echo ""

--- a/addons/knative/enable
+++ b/addons/knative/enable
@@ -78,28 +78,28 @@ fi
 
 # Handle Knative CLIs
 if [ ! -f "${SNAP_COMMON}/plugins/kn" ]; then
-  echo "Fetching Knative CLI version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn"
-  run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn"
-  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn"
+  echo "Fetching Knative CLI version ${KNATIVE_VERSION} in $SNAP_COMMON}/plugins/kn"
+  run_with_sudo mkdir -p "${SNAP_COMMON}/plugins"
+  fetch_as https://github.com/knative/client/releases/download/knative-v${KNATIVE_VERSION}/kn-linux-${SNAP_ARCH} "${SNAP_COMMON}/plugins/kn"
+  run_with_sudo chmod uo+x "${SNAP_COMMON}/plugins/kn"
 fi
 if [ ! -f "${SNAP_COMMON}/plugins/kn-admin" ]; then
-  echo "Fetching Knative CLI Admin plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-admin"
-  run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-admin"
-  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-admin"
+  echo "Fetching Knative CLI Admin plugin version ${KNATIVE_VERSION} in ${SNAP_COMMON}/plugins/kn-admin"
+  run_with_sudo mkdir -p "${SNAP_COMMON}/plugins"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-admin/releases/download/knative-v${KNATIVE_VERSION}/kn-admin-linux-${SNAP_ARCH} "${SNAP_COMMON}/plugins/kn-admin"
+  run_with_sudo chmod uo+x "${SNAP_COMMON}/plugins/kn-admin"
 fi
 if [ ! -f "${SNAP_COMMON}/plugins/kn-event" ]; then
-  echo "Fetching Knative CLI Event plugin version ${KNATIVE_VERSION} in $SNAP_DATA/bin/kn-event"
-  run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${SNAP_ARCH} "$SNAP_DATA/bin/kn-event"
-  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-event"
+  echo "Fetching Knative CLI Event plugin version ${KNATIVE_VERSION} in ${SNAP_COMMON}/plugins/kn-event"
+  run_with_sudo mkdir -p "${SNAP_COMMON}/plugins"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-event/releases/download/knative-v${KNATIVE_VERSION}/kn-event-linux-${SNAP_ARCH} "${SNAP_COMMON}/plugins/kn-event"
+  run_with_sudo chmod uo+x "${SNAP_COMMON}/plugins/kn-event"
 fi
 if [ ! -f "${SNAP_COMMON}/plugins/kn-func" ] && [ "${SNAP_ARCH}" = "amd64" ]; then
-  echo "Fetching Knative Functions plugin version ${KNATIVE_FUNC_VERSION} in $SNAP_DATA/bin/kn-func"
-  run_with_sudo mkdir -p "$SNAP_DATA/bin"
-  fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${SNAP_ARCH} "$SNAP_DATA/bin/kn-func"
-  run_with_sudo chmod uo+x "$SNAP_DATA/bin/kn-func"
+  echo "Fetching Knative Functions plugin version ${KNATIVE_FUNC_VERSION} in ${SNAP_COMMON}/plugins/kn-func"
+  run_with_sudo mkdir -p "${SNAP_COMMON}/plugins"
+  fetch_as https://github.com/knative-sandbox/kn-plugin-func/releases/download/v${KNATIVE_FUNC_VERSION}/func_linux_${SNAP_ARCH} "${SNAP_COMMON}/plugins/kn-func"
+  run_with_sudo chmod uo+x "${SNAP_COMMON}/plugins/kn-func"
 fi
 
 if [ "$KNATIVE_SERVING" = "true" ]; then

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -141,29 +141,25 @@ class TestAddons(object):
         microk8s_disable("inaccel")
 
     @pytest.mark.skipif(
-        platform.machine() != "x86_64",
-        reason="Istio tests are only relevant in x86 architectures",
+        platform.machine() == "s390x",
+        reason="Not available on s390x"
     )
     @pytest.mark.skipif(
         os.environ.get("UNDER_TIME_PRESSURE") == "True",
-        reason="Skipping istio and knative tests as we are under time pressure",
+        reason="Skipping knative tests as we are under time pressure",
     )
-    def test_knative_istio(self):
+    def test_knative(self):
         """
-        Sets up and validate istio.
+        Test knative
+        """
 
-        """
-        print("Enabling Knative and Istio")
+        print("Enabling Knative")
         microk8s_enable("knative")
-        print("Validating Istio")
-        validate_istio()
         print("Validating Knative")
         validate_knative()
         print("Disabling Knative")
         microk8s_disable("knative")
         wait_for_namespace_termination("knative-serving", timeout_insec=600)
-        print("Disabling Istio")
-        microk8s_disable("istio")
 
     @pytest.mark.skipif(
         platform.machine() != "x86_64",

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -140,10 +140,7 @@ class TestAddons(object):
         print("Disable inaccel")
         microk8s_disable("inaccel")
 
-    @pytest.mark.skipif(
-        platform.machine() == "s390x",
-        reason="Not available on s390x"
-    )
+    @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     @pytest.mark.skipif(
         os.environ.get("UNDER_TIME_PRESSURE") == "True",
         reason="Skipping knative tests as we are under time pressure",

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -276,7 +276,7 @@ def validate_knative():
     """
 
     wait_for_installation()
-    knative_services = ["activator", "autoscaler", "controller"]
+    knative_services = ["activator", "autoscaler", "controller", "domain-mapping", "autoscaler-hpa", "domainmapping-webhook", "webhook", "net-kourier-controller", "app=3scale-kourier-gateway"]
     for service in knative_services:
         wait_for_pod_state(
             "", "knative-serving", "running", label="app={}".format(service)

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -285,7 +285,7 @@ def validate_knative():
         "domainmapping-webhook",
         "webhook",
         "net-kourier-controller",
-        "app=3scale-kourier-gateway",
+        "3scale-kourier-gateway",
     ]
     for service in knative_services:
         wait_for_pod_state(

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -272,11 +272,8 @@ def validate_istio():
 
 def validate_knative():
     """
-    Validate Knative by deploying the helloworld-go app.
+    Validate Knative by deploying the helloworld-go app supports both amd64 and arm64
     """
-    if platform.machine() != "x86_64":
-        print("Knative tests are only relevant in x86 architectures")
-        return
 
     wait_for_installation()
     knative_services = ["activator", "autoscaler", "controller"]

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -276,7 +276,17 @@ def validate_knative():
     """
 
     wait_for_installation()
-    knative_services = ["activator", "autoscaler", "controller", "domain-mapping", "autoscaler-hpa", "domainmapping-webhook", "webhook", "net-kourier-controller", "app=3scale-kourier-gateway"]
+    knative_services = [
+        "activator",
+        "autoscaler",
+        "controller",
+        "domain-mapping",
+        "autoscaler-hpa",
+        "domainmapping-webhook",
+        "webhook",
+        "net-kourier-controller",
+        "app=3scale-kourier-gateway",
+    ]
     for service in knative_services:
         wait_for_pod_state(
             "", "knative-serving", "running", label="app={}".format(service)


### PR DESCRIPTION
**Please reference the issue this PR is fixing, or provide a description of the problem addressed.**
Fixes #2720
Knative addon updates:
- Update to version 1.6
- Adds arm64
- Remove dependency on istio and replace with more simple native knative network layer kourier

Fixes:
- https://github.com/ubuntu/microk8s/issues/2720
- https://github.com/ubuntu/microk8s/issues/2118

**Also verify you have:**
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
