### PR TITLE
ArgoCD upgrade&cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # microk8s-addons
 
-This repository contains the core addons that ship along with MicroK8s.
+This repository contains the community addons that can be enabled along with MicroK8s.
 
 ## Directory structure
 

--- a/addons/argocd/disable
+++ b/addons/argocd/disable
@@ -10,15 +10,6 @@ KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 HELM="$SNAP_DATA/bin/helm3 --kubeconfig=$SNAP_DATA/credentials/client.config"
 KUBECTL_DELETE_ARGS="--wait=true --timeout=180s --ignore-not-found=true"
 
-echo "Disabling ArgoCD"
-
-$HELM delete argo-cd -n $NAMESPACE_ARGOCD
-
-$KUBECTL delete customresourcedefinition applications.argoproj.io \
-                applicationsets.argoproj.io \
-                argocdextensions.argoproj.io  \
-                appprojects.argoproj.io
-
 PURGE=false
 # get the options
 while getopts ":p" flag; do
@@ -35,6 +26,15 @@ while getopts ":p" flag; do
              ;;
   esac
 done
+
+echo "Disabling ArgoCD"
+
+$HELM delete argo-cd -n $NAMESPACE_ARGOCD
+
+$KUBECTL delete customresourcedefinition applications.argoproj.io \
+                applicationsets.argoproj.io \
+                argocdextensions.argoproj.io  \
+                appprojects.argoproj.io
 
 if $PURGE; then
     echo "Final \"$NAMESPACE_ARGOCD\" namespace deletion"

--- a/addons/argocd/disable
+++ b/addons/argocd/disable
@@ -15,9 +15,18 @@ echo "Disabling ArgoCD"
 $HELM delete argo-cd -n $NAMESPACE_ARGOCD
 
 $KUBECTL delete customresourcedefinition applications.argoproj.io \
+                applicationsets.argoproj.io \
                 argocdextensions.argoproj.io  \
                 appprojects.argoproj.io
 
-$KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_ARGOCD" > /dev/null 2>&1 || true
+if [[ "$1" == "--purge" ]]; then
+    $KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_ARGOCD" > /dev/null 2>&1 || true
+else
+    echo ""
+    echo "WARNING: Deletion of \"$NAMESPACE_ARGOCD\" namespace must be enforced by: microk8s disable argocd --purge"
+    echo ""
+    echo "Purge only when sure, that \"$NAMESPACE_ARGOCD\" namespace is not hosting any other services from Argo stack."
+    echo ""
+fi
 
 echo "ArgoCD disabled"

--- a/addons/argocd/enable
+++ b/addons/argocd/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_ARGOCD="argocd"
 
-ARGOCD_HELM_VERSION="4.5.0"
+ARGOCD_HELM_VERSION="4.6.3"
 
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 


### PR DESCRIPTION
1. Upgrading ArgoCD to the latest version
2. Fixing incomplete cleanup (ArgoCD Custom Resources)
3. (optional) Conditional deletion of "argocd" namespace. Preventing accidental removal of all other Argo components sharing the same namespace. Oftentimes e.g. ArgoCD Image Updater or Argo Notifications share the same namespace with ArgoCD. Current version of deletion script may destroy complete Argo stack (regardless whether the other components are deployed as Addons or manually). Copy-pasting of this logic to further Argo Addons can even increase the danger.
4. ~~Fixes: #50~~ 

---

**Small glitch:**
- When microk8s has added community repo and my forked repo in parallel,
$ microk8s addons repo list
REPO       ADDONS SOURCE
core           17 (built-in)
**mycommunity     17 https://github.com/jkosik/microk8s-community-addons@0f1081**
**community      17 /snap/microk8s/current/addons/community@854c00**

- installation of my fork: 
$ microk8s enable mycommunity/argocd

- results in false reporting of installed Addons:
ubuntu@master:~$ microk8s status
...snipped...
addons:
  enabled:
     **argocd               # (community) Argo CD is a declarative continuous deployment for Kubernetes.**
     community            # (core) The community addons repository
     dns                  # (core) CoreDNS
     ha-cluster           # (core) Configure high availability on the current node
     helm3                # (core) Helm 3 - Kubernetes package manager
     **argocd               # (mycommunity) Argo CD is a declarative continuous deployment for Kubernetes.**

Seems as just reporting issue with colliding Addon names, since **forked** Addon was properly installed. Disabling Addon removes both clones from the list.
Worth issuing a bug?

BTW, great job with Microk8s!!!