### PR TITLE
Added skips to cilium, multus and kata in strict testing

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -192,6 +192,10 @@ class TestAddons(object):
         microk8s_disable("fluentd")
 
     @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping cilium tests in strict confinement as they are expected to fail",
+    )
+    @pytest.mark.skipif(
         platform.machine() != "x86_64",
         reason="Cilium tests are only relevant in x86 architectures",
     )
@@ -256,6 +260,10 @@ class TestAddons(object):
         print("Disabling Ambassador")
         microk8s_disable("ambassador")
 
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping multus tests in strict confinement as they are expected to fail",
+    )
     @pytest.mark.skipif(
         platform.machine() != "x86_64",
         reason="Multus tests are only relevant in x86 architectures",
@@ -382,6 +390,10 @@ class TestAddons(object):
             print("Nothing to do, since iscsid is not available")
             return
 
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping kata tests in strict confinement as they are expected to fail",
+    )
     @pytest.mark.skipif(
         platform.machine() != "x86_64",
         reason="Kata tests are only relevant in x86 architectures",


### PR DESCRIPTION
### Summary
Added a `skipif` based on `STRICT` env variable for cilium, multus and kata tests in strict since they are expected to fail

### Testing
Add `STRICT="yes"` to the environment variables before calling `pytest`. E.g.
```
sudo STRICT="yes" pytest -s /var/snap/microk8s/common/addons/community/tests/test-addons.py
```