### PR TITLE
Disable cilium for strict not dashboard-ingress

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -5,7 +5,6 @@ microk8s-addons:
       description: "Ingress definition for Kubernetes dashboard"
       version: "1.0.0"
       check_status: "ingress.networking.k8s.io/kubernetes-dashboard-ingress"
-      confinement: "classic"
       supported_architectures:
         - arm64
         - amd64
@@ -50,6 +49,7 @@ microk8s-addons:
       description: "SDN, fast with full network policy"
       version: "1.10"
       check_status: "pod/cilium"
+      confinement: "classic"
       supported_architectures:
         - amd64
 


### PR DESCRIPTION
Bug fix: cilium is supposed to be disabled in strict, not dashboard-ingress.