### PR TITLE
Add strict flag to run-tests workflow for strict

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,5 +47,6 @@ jobs:
           sudo microk8s addons repo add community .
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
+          export STRICT="yes"
           sudo -E pytest -s -ra ./tests/test-addons.py
           sudo snap remove microk8s --purge


### PR DESCRIPTION
### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

Added a `export STRICT="yes"` so expected addons are skipped in strict testing. 

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
