### PR TITLE
Skip tests when under time pressure to get below 1h 50 min

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -122,6 +122,10 @@ class TestAddons(object):
         platform.machine() != "x86_64",
         reason="NFS tests are only relevant in x86 architectures",
     )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping multus tests as we are under time pressure",
+    )
     def test_storage_nfs(self):
         """
         Sets up and validates NFS Server Provisioner.
@@ -313,6 +317,10 @@ class TestAddons(object):
         platform.machine() != "x86_64",
         reason="OpenFaaS tests are only relevant in x86 architectures",
     )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping multus tests as we are under time pressure",
+    )
     def test_openfaas(self):
         """
         Sets up and validates OpenFaaS.
@@ -328,6 +336,10 @@ class TestAddons(object):
         platform.machine() != "x86_64",
         reason="Starboard tests are only relevant in x86 architectures",
     )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping multus tests as we are under time pressure",
+    )
     def test_starboard(self):
         """
         Sets up and validates Starboard.
@@ -342,6 +354,10 @@ class TestAddons(object):
     @pytest.mark.skipif(
         platform.machine() != "x86_64",
         reason="ArgoCD tests are only relevant in x86 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping multus tests as we are under time pressure",
     )
     def test_argocd(self):
         """


### PR DESCRIPTION
On gh we have about 1h 50m to run our tests. In this PR we skip testing of:
 - NFS storage
 - openfaas
 - starboard
 - argocd