### PR TITLE
Enable multus addon for arm64 architectures

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -56,11 +56,12 @@ microk8s-addons:
 
     - name: "multus"
       description: "Multus CNI enables attaching multiple network interfaces to pods"
-      version: "3.8.1"
+      version: "3.9"
       check_status: "${SNAP_DATA}/args/cni-network/00-multus.conf"
       confinement: "classic"
       supported_architectures:
         - amd64
+        - arm64
 
     - name: "nfs"
       description: "NFS Server Provisioner"


### PR DESCRIPTION
### Summary

Update the multus addon version and enable it for the arm64 architecture.