### PR TITLE
Ondat addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -170,6 +170,8 @@ microk8s-addons:
       description: "Cheapest, fastest and simplest way to modernize your applications"
       version: "4.2.5"
       check_status: "deployment.apps/gateway"
+      supported_architectures:
+        - amd64
 
     - name: "ondat"
       description: "Ondat is a software-defined, cloud native storage platform for Kubernetes."

--- a/addons.yaml
+++ b/addons.yaml
@@ -177,5 +177,6 @@ microk8s-addons:
       description: "Ondat is a software-defined, cloud native storage platform for Kubernetes."
       version: "latest"
       check_status: "deployment.apps/storageos-cli"
+      confinement: "classic"
       supported_architectures:
         - amd64

--- a/addons.yaml
+++ b/addons.yaml
@@ -156,3 +156,10 @@ microk8s-addons:
       check_status: "deployment.apps/sosivio-dashboard"
       supported_architectures:
         - amd64
+
+    - name: "ondat"
+      description: "Ondat is a software-defined, cloud native storage platform for Kubernetes."
+      version: "latest"
+      check_status: "deployment.apps/storageos-cli"
+      supported_architectures:
+        - amd64

--- a/addons/ondat/disable
+++ b/addons/ondat/disable
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+source "$SNAP/actions/common/utils.sh"
+
+# global colour variables.
+reset=$(tput sgr0)
+red=$(tput bold && tput setaf 1)
+green=$(tput bold && tput setaf 2)
+yellow=$(tput bold && tput setaf 3)
+
+function error() {
+	# local variable.
+	local date_time
+	date_time=$(date +'%d-%m-%Y-T%H:%M:%S%z')
+
+	echo "[$date_time]: $*" >&2
+}
+
+function main() {
+	remove_ondat_cli
+}
+
+# ***
+# uninstall the Ondat CLI from the cluster.
+# ***
+function remove_ondat_cli() {
+	# local variables.
+	local kubectl
+	local current_directory
+
+	kubectl="$SNAP/microk8s-kubectl.wrapper"
+	current_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+	# remove Ondat CLI.
+	echo "$yellow Removing 'Ondat CLI'... $reset"
+	"$kubectl" delete --filename="$current_directory"/ondat-cli.yaml
+	echo "$green Ondat CLI is removed... $reset"
+	remove_ondat
+}
+
+# ***
+# uninstall Ondat from the cluster.
+# ***
+function remove_ondat() {
+	# local variables.
+	local helm
+	local ondat_namespace
+
+	helm="$SNAP/microk8s-helm3.wrapper"
+	ondat_namespace="storageos"
+
+	# remove Ondat.
+	echo "$yellow Disabling 'Ondat' add-on ... $reset"
+	"$helm" uninstall ondat \
+		--namespace="$ondat_namespace" # --debug
+	echo "$green Ondat is disabled... $reset"
+	post_removal
+}
+
+# ***
+# post uninstall guidance for users who
+# want to permanently delete volume data
+# and metadata.
+# ***
+function post_removal() {
+	cat <<EndOfMessage
+$yellow
+  *** Delete Volume Data & Metadata (Optional) ***
+
+  Ondat stores volume data, metadata and a configuration file 
+  called 'config.json' under the '/var/lib/storageos/' directory, 
+  on each node where every Ondat daemonset pod runs.
+
+  If cluster administrators would like to permanently delete the 
+  data stored in '/var/lib/storageos/', a recommendation would be 
+  to delete the directory from each node where Ondat was running on:
+
+      rm -rf /var/lib/storageos/
+  
+  To automate the removal of '/var/lib/storageos/' in multi node clusters,
+  users can run a bash script that deploys a daemonset which will remove 
+  the Ondat data directory '/var/lib/storageos/' on the nodes.
+  For more information, review the documentation below:
+
+    https://docs.ondat.io/docs/operations/uninstall/
+$red
+  WARNING - This step is irreversible and will permanently remove 
+  any existing data in '/var/lib/storageos/'. Ensure that you have 
+  backed up your data before executing this step.
+$yellow
+$reset
+EndOfMessage
+}
+
+main "$@"

--- a/addons/ondat/disable
+++ b/addons/ondat/disable
@@ -4,12 +4,6 @@
 set -euo pipefail
 source "$SNAP/actions/common/utils.sh"
 
-# global colour variables.
-reset=$(tput sgr0)
-red=$(tput bold && tput setaf 1)
-green=$(tput bold && tput setaf 2)
-yellow=$(tput bold && tput setaf 3)
-
 function error() {
 	# local variable.
 	local date_time
@@ -34,9 +28,9 @@ function remove_ondat_cli() {
 	current_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 	# remove Ondat CLI.
-	echo "$yellow Removing 'Ondat CLI'... $reset"
+	echo "Removing 'Ondat CLI'..."
 	"$kubectl" delete --filename="$current_directory"/ondat-cli.yaml
-	echo "$green Ondat CLI is removed... $reset"
+	echo "Ondat CLI is removed..."
 	remove_ondat
 }
 
@@ -52,10 +46,10 @@ function remove_ondat() {
 	ondat_namespace="storageos"
 
 	# remove Ondat.
-	echo "$yellow Disabling 'Ondat' add-on ... $reset"
+	echo "Disabling 'Ondat' add-on ..."
 	"$helm" uninstall ondat \
 		--namespace="$ondat_namespace" # --debug
-	echo "$green Ondat is disabled... $reset"
+	echo "Ondat is disabled..."
 	post_removal
 }
 
@@ -66,31 +60,29 @@ function remove_ondat() {
 # ***
 function post_removal() {
 	cat <<EndOfMessage
-$yellow
   *** Delete Volume Data & Metadata (Optional) ***
 
-  Ondat stores volume data, metadata and a configuration file 
-  called 'config.json' under the '/var/lib/storageos/' directory, 
+  Ondat stores volume data, metadata and a configuration file
+  called 'config.json' under the '/var/lib/storageos/' directory,
   on each node where every Ondat daemonset pod runs.
 
-  If cluster administrators would like to permanently delete the 
-  data stored in '/var/lib/storageos/', a recommendation would be 
+  If cluster administrators would like to permanently delete the
+  data stored in '/var/lib/storageos/', a recommendation would be
   to delete the directory from each node where Ondat was running on:
 
       rm -rf /var/lib/storageos/
-  
+
   To automate the removal of '/var/lib/storageos/' in multi node clusters,
-  users can run a bash script that deploys a daemonset which will remove 
+  users can run a bash script that deploys a daemonset which will remove
   the Ondat data directory '/var/lib/storageos/' on the nodes.
   For more information, review the documentation below:
 
     https://docs.ondat.io/docs/operations/uninstall/
-$red
-  WARNING - This step is irreversible and will permanently remove 
-  any existing data in '/var/lib/storageos/'. Ensure that you have 
+
+  WARNING - This step is irreversible and will permanently remove
+  any existing data in '/var/lib/storageos/'. Ensure that you have
   backed up your data before executing this step.
-$yellow
-$reset
+
 EndOfMessage
 }
 

--- a/addons/ondat/disable
+++ b/addons/ondat/disable
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # shellcheck disable=SC1091
 set -euo pipefail
 source "$SNAP/actions/common/utils.sh"

--- a/addons/ondat/enable
+++ b/addons/ondat/enable
@@ -9,6 +9,9 @@ red=$(tput bold && tput setaf 1)
 green=$(tput bold && tput setaf 2)
 yellow=$(tput bold && tput setaf 3)
 
+# MicroK8s variables.
+kubectl="$SNAP/microk8s-kubectl.wrapper"
+
 function error() {
 	# local variable.
 	local date_time
@@ -46,6 +49,7 @@ function set_prerequisites() {
 # ***
 function deploy_ondat() {
 	# local variables.
+	local get_node_count
 	local helm
 	local ondat_namespace
 	local etcd_cluster_storage_class
@@ -53,6 +57,7 @@ function deploy_ondat() {
 	local etcd_cluster_requests_cpu
 	local etcd_cluster_requests_memory
 
+	get_node_count=$("$SNAP"/microk8s-kubectl.wrapper get nodes --no-headers | wc -l)
 	helm="$SNAP/microk8s-helm3.wrapper"
 	ondat_namespace="storageos"
 	etcd_cluster_storage_class="microk8s-hostpath"
@@ -60,33 +65,49 @@ function deploy_ondat() {
 	etcd_cluster_requests_cpu="100m"
 	etcd_cluster_requests_memory="300Mi"
 
-	# install Ondat.
-	cat <<EndOfMessage
-$yellow
-  *** Ondat 'etcd' Cluster Replicas Sizing Guide ***
-    
-  - Single-node Cluster (=1 node)   = '1' etcd replica.
-  - Multi-node Cluster  (=3 nodes)  = '3' etcd replcias (For Test Environments).
-  - Multi-node Cluster  (>=5 nodes) = '5' etcd replcias (For Prod Environments).
-$reset
-EndOfMessage
-	read -rp "$yellow Number of 'etcd' replicas to create (Min= 1, Max = 5): $reset" etcd_cluster_replica_count
-	echo " "
-	if [[ "$etcd_cluster_replica_count" -gt 0 && "$etcd_cluster_replica_count" -le 5 ]]; then
-		echo "$yellow Enabling 'Ondat' add-on... $reset"
-		"$helm" repo add ondat https://ondat.github.io/charts
-		"$helm" repo update
+	# Setup Ondat Helm chart repository.
+	"$helm" repo add ondat https://ondat.github.io/charts
+	"$helm" repo update
+
+	# Install Ondat.
+	if [[ "$get_node_count" -le "2" ]]; then
+		echo "$yellow Detected: $get_node_count node(s)... $reset"
+		echo "$yellow Enabling 'Ondat' add-on with '1' etcd replica... $reset"
 		"$helm" install ondat ondat/ondat \
 			--create-namespace \
 			--namespace="$ondat_namespace" \
 			--set etcd-cluster-operator.cluster.storageclass="$etcd_cluster_storage_class" \
-			--set etcd-cluster-operator.cluster.replicas="$etcd_cluster_replica_count" \
+			--set etcd-cluster-operator.cluster.replicas=1 \
+			--set etcd-cluster-operator.cluster.storage="$etcd_cluster_storage_size" \
+			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
+			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
+		"$kubectl" scale --replicas=1 deployment storageos-etcd-controller-manager --namespace="$ondat_namespace"
+		echo "$green Ondat is enabled... $reset"
+	elif [[ "$get_node_count" -ge "3" && "$get_node_count" -le "4" ]]; then
+		echo "$yellow Detected: $get_node_count nodes... $reset"
+		echo "$yellow Enabling 'Ondat' add-on with '3' etcd replicas... $reset"
+		"$helm" install ondat ondat/ondat \
+			--create-namespace \
+			--namespace="$ondat_namespace" \
+			--set etcd-cluster-operator.cluster.storageclass="$etcd_cluster_storage_class" \
+			--set etcd-cluster-operator.cluster.replicas=3 \
 			--set etcd-cluster-operator.cluster.storage="$etcd_cluster_storage_size" \
 			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
 			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
 		echo "$green Ondat is enabled... $reset"
+	elif [[ "$get_node_count" -ge "5" ]]; then
+		echo "$yellow Detected: $get_node_count nodes... $reset"
+		echo "$yellow Enabling 'Ondat' add-on with '5' etcd replicas... $reset"
+		"$helm" install ondat ondat/ondat \
+			--create-namespace \
+			--namespace="$ondat_namespace" \
+			--set etcd-cluster-operator.cluster.storageclass="$etcd_cluster_storage_class" \
+			--set etcd-cluster-operator.cluster.replicas=5 \
+			--set etcd-cluster-operator.cluster.storage="$etcd_cluster_storage_size" \
+			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
+			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
 	else
-		error "$red Ensure that you enter a natural number greater than '0' or less than/equal to '5'... $reset"
+		error "$red Cannot install Ondat, check and ensure that your cluster nodes are healthy... $reset"
 		exit 1
 	fi
 	deploy_ondat_cli
@@ -100,10 +121,8 @@ EndOfMessage
 # ***
 function deploy_ondat_cli() {
 	# local variables.
-	local kubectl
 	local current_directory
 
-	kubectl="$SNAP/microk8s-kubectl.wrapper"
 	current_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 	# install Ondat CLI.

--- a/addons/ondat/enable
+++ b/addons/ondat/enable
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+source "$SNAP/actions/common/utils.sh"
+
+# global colour variables.
+reset=$(tput sgr0)
+red=$(tput bold && tput setaf 1)
+green=$(tput bold && tput setaf 2)
+yellow=$(tput bold && tput setaf 3)
+
+function error() {
+	# local variable.
+	local date_time
+	date_time=$(date +'%d-%m-%Y-T%H:%M:%S%z')
+
+	echo "[$date_time]: $*" >&2
+}
+
+function main() {
+	set_prerequisites
+}
+
+# enable microk8s add-on dependencies
+# (dns, hostpath-storage, helm3) that
+# are required for Ondat to run.
+function set_prerequisites() {
+	# local variables.
+	local enable_addon
+	enable_addon="$SNAP/microk8s-enable.wrapper"
+
+	# enable Ondat add-on dependencies.
+	echo "$yellow Enabling CoreDNS for Service Discovery... $reset"
+	"$enable_addon" dns
+	echo "$yellow Enabling Hostpath Storage for Ondat's etcd Cluster... $reset"
+	"$enable_addon" hostpath-storage
+	echo "$yellow Enabling Helm 3 Package Manager to deploy the Ondat Helm Chart... $reset"
+	"$enable_addon" helm3
+	echo "$green Ondat dependency add-ons enabled... $reset"
+	deploy_ondat
+}
+
+# ***
+# install Ondat into a microk8s cluster
+# through the official Helm chart.
+# ***
+function deploy_ondat() {
+	# local variables.
+	local helm
+	local ondat_namespace
+	local etcd_cluster_storage_class
+	local etcd_cluster_storage_size
+	local etcd_cluster_requests_cpu
+	local etcd_cluster_requests_memory
+
+	helm="$SNAP/microk8s-helm3.wrapper"
+	ondat_namespace="storageos"
+	etcd_cluster_storage_class="microk8s-hostpath"
+	etcd_cluster_storage_size="6Gi"
+	etcd_cluster_requests_cpu="100m"
+	etcd_cluster_requests_memory="300Mi"
+
+	# install Ondat.
+	cat <<EndOfMessage
+$yellow
+  *** Ondat 'etcd' Cluster Replicas Sizing Guide ***
+    
+  - Single-node Cluster (=1 node)   = '1' etcd replica.
+  - Multi-node Cluster  (=3 nodes)  = '3' etcd replcias (For Test Environments).
+  - Multi-node Cluster  (>=5 nodes) = '5' etcd replcias (For Prod Environments).
+$reset
+EndOfMessage
+	read -rp "$yellow Number of 'etcd' replicas to create (Min= 1, Max = 5): $reset" etcd_cluster_replica_count
+	echo " "
+	if [[ "$etcd_cluster_replica_count" -gt 0 && "$etcd_cluster_replica_count" -le 5 ]]; then
+		echo "$yellow Enabling 'Ondat' add-on... $reset"
+		"$helm" repo add ondat https://ondat.github.io/charts
+		"$helm" repo update
+		"$helm" install ondat ondat/ondat \
+			--create-namespace \
+			--namespace="$ondat_namespace" \
+			--set etcd-cluster-operator.cluster.storageclass="$etcd_cluster_storage_class" \
+			--set etcd-cluster-operator.cluster.replicas="$etcd_cluster_replica_count" \
+			--set etcd-cluster-operator.cluster.storage="$etcd_cluster_storage_size" \
+			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
+			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
+		echo "$green Ondat is enabled... $reset"
+	else
+		error "$red Ensure that you enter a natural number greater than '0' or less than/equal to '5'... $reset"
+		exit 1
+	fi
+	deploy_ondat_cli
+}
+
+# ***
+# install the Ondat CLI into a microk8s
+# cluster to manage and configure Ondat
+# resources and conduct Day-2 storage
+# operations.
+# ***
+function deploy_ondat_cli() {
+	# local variables.
+	local kubectl
+	local current_directory
+
+	kubectl="$SNAP/microk8s-kubectl.wrapper"
+	current_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+	# install Ondat CLI.
+	echo "$yellow Deploying 'Ondat CLI'... $reset"
+	"$kubectl" apply --filename="$current_directory"/ondat-cli.yaml
+	echo "$green Ondat CLI is deployed... $reset"
+	post_install
+}
+
+# ***
+# post install guidance and details on how
+# to get help or getting started with Ondat.
+# ***
+function post_install() {
+	cat <<EndOfMessage
+$yellow
+  *** Getting Started With Ondat ***
+    
+  Get your free Community edition licence by 
+  signing up and register your cluster through 
+  Ondat's SaaS platform:
+    
+    https://portal.ondat.io/
+  
+  Create your first Ondat volume with your microK8s
+  cluster by following the how-to guide below:
+    
+    https://docs.ondat.io/docs/operations/firstpvc/
+
+  To interact with your Ondat cluster and conduct 
+  Day-2 storage operations, use the Ondat CLI that 
+  is deployed in your microK8s cluster:
+  
+    https://docs.ondat.io/docs/reference/cli/#usage
+$reset
+EndOfMessage
+}
+
+main "$@"

--- a/addons/ondat/enable
+++ b/addons/ondat/enable
@@ -3,12 +3,6 @@
 set -euo pipefail
 source "$SNAP/actions/common/utils.sh"
 
-# global colour variables.
-reset=$(tput sgr0)
-red=$(tput bold && tput setaf 1)
-green=$(tput bold && tput setaf 2)
-yellow=$(tput bold && tput setaf 3)
-
 # MicroK8s variables.
 kubectl="$SNAP/microk8s-kubectl.wrapper"
 
@@ -33,13 +27,13 @@ function set_prerequisites() {
 	enable_addon="$SNAP/microk8s-enable.wrapper"
 
 	# enable Ondat add-on dependencies.
-	echo "$yellow Enabling CoreDNS for Service Discovery... $reset"
+	echo "Enabling CoreDNS for Service Discovery..."
 	"$enable_addon" dns
-	echo "$yellow Enabling Hostpath Storage for Ondat's etcd Cluster... $reset"
+	echo "Enabling Hostpath Storage for Ondat's etcd Cluster..."
 	"$enable_addon" hostpath-storage
-	echo "$yellow Enabling Helm 3 Package Manager to deploy the Ondat Helm Chart... $reset"
+	echo "Enabling Helm 3 Package Manager to deploy the Ondat Helm Chart..."
 	"$enable_addon" helm3
-	echo "$green Ondat dependency add-ons enabled... $reset"
+	echo "Ondat dependency add-ons enabled..."
 	deploy_ondat
 }
 
@@ -71,8 +65,8 @@ function deploy_ondat() {
 
 	# Install Ondat.
 	if [[ "$get_node_count" -le "2" ]]; then
-		echo "$yellow Detected: $get_node_count node(s)... $reset"
-		echo "$yellow Enabling 'Ondat' add-on with '1' etcd replica... $reset"
+		echo "Detected: $get_node_count node(s)..."
+		echo "Enabling 'Ondat' add-on with '1' etcd replica..."
 		"$helm" install ondat ondat/ondat \
 			--create-namespace \
 			--namespace="$ondat_namespace" \
@@ -82,10 +76,10 @@ function deploy_ondat() {
 			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
 			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
 		"$kubectl" scale --replicas=1 deployment storageos-etcd-controller-manager --namespace="$ondat_namespace"
-		echo "$green Ondat is enabled... $reset"
+		echo "Ondat is enabled..."
 	elif [[ "$get_node_count" -ge "3" && "$get_node_count" -le "4" ]]; then
-		echo "$yellow Detected: $get_node_count nodes... $reset"
-		echo "$yellow Enabling 'Ondat' add-on with '3' etcd replicas... $reset"
+		echo "Detected: $get_node_count nodes..."
+		echo "Enabling 'Ondat' add-on with '3' etcd replicas..."
 		"$helm" install ondat ondat/ondat \
 			--create-namespace \
 			--namespace="$ondat_namespace" \
@@ -94,10 +88,10 @@ function deploy_ondat() {
 			--set etcd-cluster-operator.cluster.storage="$etcd_cluster_storage_size" \
 			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
 			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
-		echo "$green Ondat is enabled... $reset"
+		echo "Ondat is enabled..."
 	elif [[ "$get_node_count" -ge "5" ]]; then
-		echo "$yellow Detected: $get_node_count nodes... $reset"
-		echo "$yellow Enabling 'Ondat' add-on with '5' etcd replicas... $reset"
+		echo "Detected: $get_node_count nodes..."
+		echo "Enabling 'Ondat' add-on with '5' etcd replicas..."
 		"$helm" install ondat ondat/ondat \
 			--create-namespace \
 			--namespace="$ondat_namespace" \
@@ -107,7 +101,7 @@ function deploy_ondat() {
 			--set etcd-cluster-operator.cluster.resources.requests.cpu="$etcd_cluster_requests_cpu" \
 			--set etcd-cluster-operator.cluster.resources.requests.memory="$etcd_cluster_requests_memory" # --debug
 	else
-		error "$red Cannot install Ondat, check and ensure that your cluster nodes are healthy... $reset"
+		error "Cannot install Ondat, check and ensure that your cluster nodes are healthy..."
 		exit 1
 	fi
 	deploy_ondat_cli
@@ -126,9 +120,9 @@ function deploy_ondat_cli() {
 	current_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 	# install Ondat CLI.
-	echo "$yellow Deploying 'Ondat CLI'... $reset"
+	echo "Deploying 'Ondat CLI'..."
 	"$kubectl" apply --filename="$current_directory"/ondat-cli.yaml
-	echo "$green Ondat CLI is deployed... $reset"
+	echo "Ondat CLI is deployed..."
 	post_install
 }
 
@@ -138,7 +132,6 @@ function deploy_ondat_cli() {
 # ***
 function post_install() {
 	cat <<EndOfMessage
-$yellow
   *** Getting Started With Ondat ***
     
   Get your free Community edition licence by 
@@ -157,7 +150,6 @@ $yellow
   is deployed in your microK8s cluster:
   
     https://docs.ondat.io/docs/reference/cli/#usage
-$reset
 EndOfMessage
 }
 

--- a/addons/ondat/ondat-cli.yaml
+++ b/addons/ondat/ondat-cli.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: storageos-cli
+    app.kubernetes.io/component: storageos-cli
+    app.kubernetes.io/part-of: storageos
+    kind: storageos
+  name: storageos-cli
+  namespace: storageos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: storageos-cli
+  template:
+    metadata:
+      labels:
+        app: storageos-cli
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - while true; do sleep 3600; done
+          env:
+            - name: STORAGEOS_USERNAME
+              value: storageos
+            - name: STORAGEOS_PASSWORD
+              value: storageos
+            - name: STORAGEOS_ENDPOINTS
+              value: storageos:5705
+          image: storageos/cli:v2.8.1
+          imagePullPolicy: Always
+          name: cli
+          ports:
+            - containerPort: 5705
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true

--- a/addons/ondat/ondat-cli.yaml
+++ b/addons/ondat/ondat-cli.yaml
@@ -30,7 +30,7 @@ spec:
               value: storageos
             - name: STORAGEOS_ENDPOINTS
               value: storageos:5705
-          image: storageos/cli:v2.8.1
+          image: storageos/cli:v2.9.0
           imagePullPolicy: Always
           name: cli
           ports:

--- a/addons/ondat/ondat-cli.yaml
+++ b/addons/ondat/ondat-cli.yaml
@@ -25,9 +25,17 @@ spec:
             - while true; do sleep 3600; done
           env:
             - name: STORAGEOS_USERNAME
-              value: storageos
+              valueFrom:
+                secretKeyRef:
+                  name: storageos-api
+                  key: username
+                  optional: false
             - name: STORAGEOS_PASSWORD
-              value: storageos
+              valueFrom:
+                secretKeyRef:
+                  name: storageos-api
+                  key: password
+                  optional: false
             - name: STORAGEOS_ENDPOINTS
               value: storageos:5705
           image: storageos/cli:v2.9.0

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -486,10 +486,6 @@ class TestAddons(object):
         platform.machine() != "x86_64",
         reason="Ondat tests are only relevant in x86 architectures",
     )
-    @pytest.mark.skipif(
-        os.environ.get("UNDER_TIME_PRESSURE") == "True",
-        reason="Skipping Ondat tests as we are under time pressure",
-    )
     def test_ondat(self):
         """
         Setup and validates Ondat.

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -37,6 +37,7 @@ from validators import (
     validate_argocd,
     validate_osm_edge,
     validate_sosivio,
+    validate_ondat,
 )
 from utils import (
     microk8s_enable,
@@ -480,3 +481,22 @@ class TestAddons(object):
         validate_sosivio()
         print("Disabling sosivio")
         microk8s_disable("sosivio")
+
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="Ondat tests are only relevant in x86 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping Ondat tests as we are under time pressure",
+    )
+    def test_ondat(self):
+        """
+        Setup and validates Ondat.
+        """
+        print("Enabling Ondat.")
+        microk8s_enable("ondat")
+        print("Validating Ondat.")
+        validate_ondat()
+        print("Disabling Ondat.")
+        microk8s_disable("ondat")

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -529,6 +529,10 @@ class TestAddons(object):
         reason = ("Sosivio tests are only relevant in x86 architectures",)
 
     @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping nfs tests in strict confinement as they are expected to fail",
+    )
+    @pytest.mark.skipif(
         platform.machine() != "x86_64",
         reason="Ondat tests are only relevant in x86 architectures",
     )

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -742,11 +742,10 @@ def validate_ondat():
     if platform.machine() != "x86_64":
         print("Ondat tests are only relevant in x86 architectures")
         return
-    wait_for_installation()
     wait_for_pod_state(
-        "storageos-cli", "storageos", "running", label="app=storageos-cli"
+        "", "storageos", "running", label="app=storageos-cli"
     )
     wait_for_pod_state(
-        "ondat-ondat-operator", "storageos", "running", label="app=ondat-operator"
+        "", "storageos", "running", label="app=ondat-operator"
     )
-    wait_for_pod_state("storageos-node", "storageos", "running", label="app=storageos")
+    wait_for_pod_state("", "storageos", "running", label="app=storageos")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -709,6 +709,7 @@ def validate_sosivio():
     )
     print("sosivio is up and running")
 
+
 def validate_kwasm():
     """
     Validate kwasm
@@ -732,6 +733,7 @@ def validate_gopaddle_lite():
     Validate gopaddle-lite
     """
     wait_for_pod_state("", "gp-lite", "running", label="released-by=gopaddle")
+
 
 def validate_ondat():
     """

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -742,10 +742,6 @@ def validate_ondat():
     if platform.machine() != "x86_64":
         print("Ondat tests are only relevant in x86 architectures")
         return
-    wait_for_pod_state(
-        "", "storageos", "running", label="app=storageos-cli"
-    )
-    wait_for_pod_state(
-        "", "storageos", "running", label="app=ondat-operator"
-    )
+    wait_for_pod_state("", "storageos", "running", label="app=storageos-cli")
+    wait_for_pod_state("", "storageos", "running", label="app=ondat-operator")
     wait_for_pod_state("", "storageos", "running", label="app=storageos")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -708,3 +708,20 @@ def validate_sosivio():
         timeout_insec=300,
     )
     print("sosivio is up and running")
+
+
+def validate_ondat():
+    """
+    Validate the Ondat addon.
+    """
+    if platform.machine() != "x86_64":
+        print("Ondat tests are only relevant in x86 architectures")
+        return
+    wait_for_installation()
+    wait_for_pod_state(
+        "storageos-cli", "storageos", "running", label="app=storageos-cli"
+    )
+    wait_for_pod_state(
+        "ondat-ondat-operator", "storageos", "running", label="app=ondat-operator"
+    )
+    wait_for_pod_state("storageos-node", "storageos", "running", label="app=storageos")


### PR DESCRIPTION
# Overview

- This is an Ondat add-on that provides a software-defined, cloud native storage platform for [MicroK8s](https://github.com/canonical/microk8s)

## Dependencies

- For Ondat to be successfully deployed onto a MicroK8s cluster, the following [Core add-ons](https://microk8s.io/docs/addon-dns) should be available:
  - [dns](https://microk8s.io/docs/addon-dns) - [CoreDNS](https://coredns.io/) to provide address resolution services and service discovery in your MicroK8s cluster.
  - [hostpath-storage](https://microk8s.io/docs/addon-hostpath-storage) - Host storage for Ondat's etcd cluster.
  - [helm3](https://helm.sh/) - Helm 3 package manager for Kubernetes to deploy the Ondat Helm chart.

> 💡 The Ondat add-on will automatically check and deploy the required core add-ons if they are not already deployed in the MicroK8s cluster.

## Supported Distributions

Tested on the following Ubuntu distributions:
- Ubuntu 22.04 LTS (Jammy Jellyfish)
- Ubuntu 20.04 LTS (Focal Fossa)
- Ubuntu 18.04 LTS (Bionic Beaver)

Tested on the following architectures:
- x86-64

## Enabling Ondat Workflow

```yaml
# microk8s enable ondat
Infer repository core for addon ondat
 Enabling CoreDNS for Service Discovery...
Infer repository core for addon dns
Addon core/dns is already enabled
 Enabling Hostpath Storage for Ondat's etcd Cluster...
Infer repository core for addon hostpath-storage
Addon core/hostpath-storage is already enabled
 Enabling Helm 3 Package Manager to deploy the Ondat Helm Chart...
Infer repository core for addon helm3
Addon core/helm3 is already enabled
 Ondat dependency add-ons enabled...

  *** Ondat 'etcd' Cluster Replicas Sizing Guide ***

  - Single-node Cluster            = '1' etcd replica.
  - Multi-node Cluster (=3 nodes)  = '3' etcd replcias (For Test Environments).
  - Multi-node Cluster (>=5 nodes) = '5' etcd replcias (For Prod Environments).

 Number of 'etcd' replicas to create (Min= 1, Max = 5): 1

 Enabling 'Ondat' add-on...
"ondat" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "ondat" chart repository
Update Complete. ⎈Happy Helming!⎈
NAME: ondat
LAST DEPLOYED: Fri Sep 30 15:56:04 2022
NAMESPACE: storageos
STATUS: deployed
REVISION: 1
TEST SUITE: None
 Ondat is enabled...
 Deploying 'Ondat CLI'...
deployment.apps/storageos-cli created
 Ondat CLI is deployed...

  *** Getting Started With Ondat ***

  Get your free Community edition licence by
  signing up and register your cluster through
  Ondat's SaaS platform:

    https://portal.ondat.io/

  Create your first Ondat volume with your microK8s
  cluster by following the how-to guide below:

    https://docs.ondat.io/docs/operations/firstpvc/

  To interact with your Ondat cluster and conduct
  Day-2 storage operations, use the Ondat CLI that
  is deployed in your microK8s cluster:

    https://docs.ondat.io/docs/reference/cli/#usage

```

## Disabling Ondat Workflow

```yaml
# microk8s disable ondat
Infer repository core for addon ondat
 Removing 'Ondat CLI'...
deployment.apps "storageos-cli" deleted
 Ondat CLI is removed...
 Disabling 'Ondat' add-on ...
release "ondat" uninstalled
 Ondat is disabled...

  *** Delete Volume Data & Metadata (Optional) ***

  Ondat stores volume data, metadata and a configuration file
  called 'config.json' under the '/var/lib/storageos/' directory,
  on each node where every Ondat daemonset pod runs.

  If cluster administrators would like to permanently delete the
  data stored in '/var/lib/storageos/', a recommendation would be
  to delete the directory from each node where Ondat was running on:

      rm -rf /var/lib/storageos/

  To automate the removal of '/var/lib/storageos/' in multi node clusters,
  users can run a bash script that deploys a daemonset which will remove
  the Ondat data directory '/var/lib/storageos/' on the nodes.
  For more information, review the documentation below:

    https://docs.ondat.io/docs/operations/uninstall/

  WARNING - This step is irreversible and will permanently remove
  any existing data in '/var/lib/storageos/'. Ensure that you have
  backed up your data before executing this step.

```

Looking forward to any suggestions + feedback. Let me know if there is anything I have missed out.

Thanks!

* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.