### PR TITLE
moving openebs version to var OPENEBS_VERSION, setting replicas to nu…

### DIFF
--- a/addons/openebs/enable
+++ b/addons/openebs/enable
@@ -8,6 +8,7 @@ KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm3.wrapper"
 
 OPENEBS_NS="openebs"
+OPENEBS_VERSION="3.3.x"
 
 print_iscsi_help() {
     echo "Make sure iscsi is installed on all nodes."
@@ -30,12 +31,17 @@ fi
 # make sure the "openebs" namespace exist
 $KUBECTL create namespace "$OPENEBS_NS" > /dev/null 2>&1 || true
 
+# adding check for small clusters by checking number of nodes in cluster
+K8S_NODES=$( ${KUBECTL} get nodes | awk '!/NAME/{count++} END{if(count > "2"){print 3} else {print count}}' )
+echo "Setting Jiva Replicas to ${K8S_NODES}"
+
 $HELM repo add openebs https://openebs.github.io/charts
 $HELM repo update
 $HELM -n openebs install openebs openebs/openebs \
-    --version 3.0.x \
+    --version ${OPENEBS_VERSION} \
     --set cstor.enabled=true \
     --set jiva.enabled=true \
+    --set jiva.replicas=${K8S_NODES} \
     --set legacy.enabled=false \
     --set cstor.cleanup.image.tag="latest" \
     --set cstor.csiNode.kubeletDir="$SNAP_COMMON/var/lib/kubelet/" \


### PR DESCRIPTION
This PR sets out to add support for microk8s deployments with less than 3 clusters by setting the jiva replicas to the number of nodes in the cluster when the total number of clusters is less than 3 (line 35). It also moves the openebs version to 3.3.x and is now set with a variable OPENEBS_VERSION (line 11). 

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
