### PR TITLE
Adding KWasm operator addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -157,3 +157,11 @@ microk8s-addons:
       check_status: "deployment.apps/sosivio-dashboard"
       supported_architectures:
         - amd64
+
+    - name: "kwasm"
+      description: "WebAssembly support for WasmEdge (Docker Wasm) and Spin (Azure AKS WASI)"
+      version: "0.2.0"
+      check_status: "deployment.apps/kwasm-operator"
+      supported_architectures:
+        - arm64
+        - amd64

--- a/addons/kwasm/disable
+++ b/addons/kwasm/disable
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+NAMESPACE_KWASM="kwasm-system"
+
+"$SNAP/microk8s-enable.wrapper" helm3
+HELM="$SNAP/microk8s-helm3.wrapper"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+
+echo "Disabling KWasm"
+
+$HELM delete -n $NAMESPACE_KWASM kwasm-operator
+$HELM repo remove kwasm
+$KUBECTL delete ns $NAMESPACE_KWASM
+
+echo "KWasm disabled"

--- a/addons/kwasm/enable
+++ b/addons/kwasm/enable
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+NAMESPACE_KWASM="kwasm-system"
+
+"$SNAP/microk8s-enable.wrapper" helm3
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+echo "Installing KWasm"
+
+$HELM repo add --force-update kwasm http://kwasm.sh/kwasm-operator/ 
+$HELM upgrade -i -n $NAMESPACE_KWASM --create-namespace kwasm-operator kwasm/kwasm-operator \
+    --set kwasmOperator.autoProvision="true"
+
+echo "KWasm is installed"
+echo ""
+echo "If you need help to get started visit:"
+echo "    https://kwasm.sh/?dist=microk8s#Quickstart"

--- a/tests/templates/wasm-job.yaml
+++ b/tests/templates/wasm-job.yaml
@@ -1,0 +1,22 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: crun
+handler: crun
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wasm-test
+spec:
+  template:
+    metadata:
+      annotations:
+        module.wasm.image/variant: compat-smart
+    spec:
+      containers:
+      - image: wasmedge/example-wasi:latest
+        name: wasm-test
+      restartPolicy: Never
+      runtimeClassName: crun
+  backoffLimit: 1

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -37,6 +37,7 @@ from validators import (
     validate_argocd,
     validate_osm_edge,
     validate_sosivio,
+    validate_kwasm,
 )
 from utils import (
     microk8s_enable,
@@ -495,3 +496,15 @@ class TestAddons(object):
         validate_sosivio()
         print("Disabling sosivio")
         microk8s_disable("sosivio")
+
+    @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
+    def test_kwasm(self):
+        """
+        Sets up and validates kwasm.
+        """
+        print("Enabling kwasm")
+        microk8s_enable("kwasm")
+        print("Validating kwasm")
+        validate_kwasm()
+        print("Disabling kwasm")
+        microk8s_disable("kwasm")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -708,3 +708,21 @@ def validate_sosivio():
         timeout_insec=300,
     )
     print("sosivio is up and running")
+
+
+def validate_kwasm():
+    """
+    Validate kwasm
+    """
+    wait_for_pod_state(
+        "", "kwasm-system", "running", label="app.kubernetes.io/name=kwasm-operator"
+    )
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    manifest = os.path.join(here, "templates", "wasm-job.yaml")
+    kubectl("apply -f {}".format(manifest))
+    wait_for_pod_state(
+        "", "default", "terminated", "Completed", label="job-name=wasm-test"
+    )
+    kubectl("delete -f {}".format(manifest))
+    print("kwasm is up and running")


### PR DESCRIPTION
This PR replaces PR #28. The [KWasm operator](https://github.com/KWasm/kwasm-operator) manages an installer image that installs WasmEdge (the runtime used by Docker) and Fermyon Spin (the framework used by Azure). That makes it possible to run Wasm images built for Docker or Spin images that run on Azures AKS WASI preview.

closes #27 (issue)
closes #28 (pr)

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
