### PR TITLE
Enable istio on arm64

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -15,6 +15,7 @@ microk8s-addons:
       check_status: "${SNAP_DATA}/bin/istioctl"
       supported_architectures:
         - amd64
+        - arm64
 
     - name: "knative"
       description: "Knative Serverless and Event Driven Applications"


### PR DESCRIPTION
### Summary

Fixes https://github.com/canonical/microk8s/issues/3168

With the upgrade to Istio 1.15.3, we get arm64 support:

```
ubuntu@wayfarer ~ $ docker manifest inspect docker.io/istio/pilot:1.15.3
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1241,
         "digest": "sha256:b08b6e16576d36b1903c82e40c800e63b6de35a5964bb13a9db122f0fa5298d5",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1241,
         "digest": "sha256:ab3b06b76c997c11da4783c4b0b2eb31aca0ad097dcdf3a7efb07adef5f4c31f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
ubuntu@wayfarer ~ $ docker manifest inspect docker.io/istio/proxyv2:1.15.3
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2058,
         "digest": "sha256:b7421689c90d26e8eeb46b9e4ed864a7929953077adfb2405c6e84c8df53a6d3",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2058,
         "digest": "sha256:aeb1a217d767771e4d867d9bd438924dd76a3939268bca3c51160314d0a3a1ad",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```

Allow microk8s to enable istio on arm64 architectures