### PR TITLE
Fix kasm amd64 support

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -163,6 +163,7 @@ microk8s-addons:
       version: "0.2.0"
       check_status: "deployment.apps/kwasm-operator"
       supported_architectures:
+        - amd64
         - arm64
 
     - name: "gopaddle-lite"


### PR DESCRIPTION
This was accidentally dropped during the gopaddle PR.