### PR TITLE
Revert "Enable istio on arm64"

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -15,7 +15,6 @@ microk8s-addons:
       check_status: "${SNAP_DATA}/bin/istioctl"
       supported_architectures:
         - amd64
-        - arm64
 
     - name: "knative"
       description: "Knative Serverless and Event Driven Applications"

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -192,6 +192,10 @@ class TestAddons(object):
         wait_for_namespace_termination("knative-serving", timeout_insec=600)
 
     @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="Istio tests are only relevant in x86 architectures",
+    )
+    @pytest.mark.skipif(
         os.environ.get("UNDER_TIME_PRESSURE") == "True",
         reason="Skipping istio and knative tests as we are under time pressure",
     )


### PR DESCRIPTION
Reverts canonical/microk8s-community-addons#105

This is not enough for the arm64 support.