### PR TITLE
Enable cilium for arm

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -51,7 +51,7 @@ microk8s-addons:
 
     - name: "cilium"
       description: "SDN, fast with full network policy"
-      version: "1.11.2"
+      version: "1.11.12"
       check_status: "pod/cilium"
       confinement: "classic"
       supported_architectures:

--- a/addons.yaml
+++ b/addons.yaml
@@ -51,11 +51,12 @@ microk8s-addons:
 
     - name: "cilium"
       description: "SDN, fast with full network policy"
-      version: "1.10"
+      version: "1.11.2"
       check_status: "pod/cilium"
       confinement: "classic"
       supported_architectures:
         - amd64
+        - arm64
 
     - name: "multus"
       description: "Multus CNI enables attaching multiple network interfaces to pods"

--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -38,10 +38,10 @@ fi
 
 echo "Enabling Cilium"
 
-# Cilium Supports Arm beginning v1.11.2 and greater
+# Cilium Supports Arm beginning v1.11.12 and greater
 read -ra CILIUM_VERSION <<< "$1"
 if [ -z "$CILIUM_VERSION" ]; then
-  CILIUM_VERSION="v1.11.2"
+  CILIUM_VERSION="v1.11.12"
 fi
 CILIUM_ERSION=$(echo $CILIUM_VERSION | sed 's/v//g')
 

--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -4,12 +4,6 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-ARCH=$(arch)
-if ! [ "${ARCH}" = "amd64" ]; then
-  echo "Cilium is not available for ${ARCH}" >&2
-  exit 1
-fi
-
 "$SNAP/microk8s-enable.wrapper" helm3
 
 echo "Ensure kube-apiserver --allow-privileged=true flag"
@@ -44,9 +38,10 @@ fi
 
 echo "Enabling Cilium"
 
+# Cilium Supports Arm beginning v1.11.2 and greater
 read -ra CILIUM_VERSION <<< "$1"
 if [ -z "$CILIUM_VERSION" ]; then
-  CILIUM_VERSION="v1.10"
+  CILIUM_VERSION="v1.11.2"
 fi
 CILIUM_ERSION=$(echo $CILIUM_VERSION | sed 's/v//g')
 


### PR DESCRIPTION
### Thank you for making MicroK8s better

Enable Cilium to be used on ARM. Cilium supports arm starting version 1.11.2 and greater.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
