### PR TITLE
Disable kwasm on strict

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -162,6 +162,7 @@ microk8s-addons:
       description: "WebAssembly support for WasmEdge (Docker Wasm) and Spin (Azure AKS WASI)"
       version: "0.2.0"
       check_status: "deployment.apps/kwasm-operator"
+      confinement: "classic"
       supported_architectures:
         - amd64
         - arm64

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -499,6 +499,10 @@ class TestAddons(object):
         print("Disabling sosivio")
         microk8s_disable("sosivio")
 
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping kwasm tests in strict confinement as they are expected to fail",
+    )
     @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     def test_kwasm(self):
         """


### PR DESCRIPTION
Disable kwasm on strict with the core20 upgrade since now `/lib` is read-only and a snap layout for it can not be created at this time.