### PR TITLE
Fix kata containers runtimeclass and pod

### DIFF
--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -72,6 +72,7 @@ def print_next_steps():
     print()
     print("To use the kata runtime set the 'kata' runtimeClassName, eg:")
     print()
+    print("apiVersion: v1")
     print("kind: Pod")
     print("metadata:")
     print("  name: nginx-kata")

--- a/addons/kata/kata/runtime.yaml
+++ b/addons/kata/kata/runtime.yaml
@@ -1,4 +1,4 @@
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: kata


### PR DESCRIPTION
### Summary

Fixes:

```
error: resource mapping not found for name: "kata" namespace: "" from "/var/snap/microk8s/common/addons/community/addons/kata/kata/runtime.yaml": no matches for kind "RuntimeClass" in version "node.k8s.io/v1beta1"
ensure CRDs are installed first
```

Also update the example to be a valid pod definition.