### PR TITLE
Add EasyHAProxy addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -181,3 +181,11 @@ microk8s-addons:
       confinement: "classic"
       supported_architectures:
         - amd64
+
+    - name: "easyhaproxy"
+      description: "EasyHAProxy can configure HAProxy automatically based on ingress labels"
+      version: "latest"
+      check_status: "pod/ingress-easyhaproxy"
+      supported_architectures:
+        - amd64
+        - arm64

--- a/addons.yaml
+++ b/addons.yaml
@@ -184,7 +184,7 @@ microk8s-addons:
 
     - name: "easyhaproxy"
       description: "EasyHAProxy can configure HAProxy automatically based on ingress labels"
-      version: "latest"
+      version: "0.1.5"
       check_status: "pod/ingress-easyhaproxy"
       supported_architectures:
         - amd64

--- a/addons/easyhaproxy/disable
+++ b/addons/easyhaproxy/disable
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+source $SNAP/actions/common/utils.sh
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+
+NAMESPACE_PTR="easyhaproxy"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+echo "Disabling EasyHAProxy Ingress Controller"
+echo
+
+
+$KUBECTL label nodes $(hostname) "easyhaproxy/node-"
+
+$HELM uninstall ingress  \
+    --namespace $NAMESPACE_PTR
+
+# $KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true

--- a/addons/easyhaproxy/enable
+++ b/addons/easyhaproxy/enable
@@ -4,12 +4,6 @@ set -e
 source $SNAP/actions/common/utils.sh
 CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
-"$SNAP/microk8s-enable.wrapper" dns
-"$SNAP/microk8s-enable.wrapper" helm3
-
-
-NAMESPACE_PTR="easyhaproxy"
-
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm3.wrapper"
 
@@ -17,6 +11,45 @@ echo "+=========================================+"
 echo "| Enabling EasyHAProxy Ingress Controller |"
 echo "+=========================================+"
 echo
+
+NODEPORTS=$($KUBECTL get svc --all-namespaces -o go-template='{{range .items}}{{range.spec.ports}}{{if .nodePort}}{{.nodePort}}{{"\n"}}{{end}}{{end}}{{end}}')
+HOSTPORTS=$($KUBECTL get ds --all-namespaces -o go-template='{{range .items}}{{range .spec.template.spec.containers}}{{range .ports}}{{if .hostPort}}{{.hostPort}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}')
+
+if [ -z "$1" ]; then
+
+    for port in $(echo $NODEPORTS $HOSTPORTS); do
+        if [[ "$port" == "80" || "$port" == "443" || "$port" == "1936" ]]; then
+            echo "Port $port is already in use. Please disable the ingress controller or use the --nodeport option."
+            exit 1
+        fi
+    done
+    echo "Port 80 and 443 are available. Installing as a Daemonset"
+
+elif [ "$1" == "--nodeport" ]; then
+
+    for port in $(echo $NODEPORTS $HOSTPORTS); do
+        if [[ "$port" == "30080" || "$port" == "30443" || "$port" == "31936" ]]; then
+            echo "Port $port is already in use. Please disable the component is using port $port."
+            exit 1
+        fi
+    done
+    echo "Port 30080 and 30443 are available. Installing as a Nodeport"
+
+else
+
+    echo 
+    echo ERROR: Invalid parameter $1
+    echo 
+    echo "You should pass 'empty' to install as a daemonset or '--nodeport' to install as nodeport"
+    echo
+    exit 1
+
+fi
+
+"$SNAP/microk8s-enable.wrapper" dns
+"$SNAP/microk8s-enable.wrapper" helm3
+
+NAMESPACE_PTR="easyhaproxy"
 
 $KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
 
@@ -50,14 +83,6 @@ elif [ "$1" == "--nodeport" ]; then
 
     echo
     echo "Installed as a Nodeport at port 30080 and 30443"
-    echo
-
-else
-
-    echo 
-    echo ERROR: Invalid parameter $1
-    echo 
-    echo "You should pass 'empty' to install as a daemonset or '--nodeport' to install as nodeport"
     echo
 
 fi

--- a/addons/easyhaproxy/enable
+++ b/addons/easyhaproxy/enable
@@ -57,10 +57,12 @@ $HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
 $HELM repo update > /dev/null 2>&1
 
 $KUBECTL label nodes $(hostname) "easyhaproxy/node=master" --overwrite
+$HELM_PACKAGE_VERSION="0.1.5"
 
 if [ -z "$1" ]; then
 
     $HELM upgrade --install ingress byjg/easyhaproxy \
+        --version $HELM_PACKAGE_VERSION \
         --namespace $NAMESPACE_PTR \
         --set resources.requests.cpu=100m \
         --set resources.requests.memory=128Mi
@@ -72,6 +74,7 @@ if [ -z "$1" ]; then
 elif [ "$1" == "--nodeport" ]; then
 
     $HELM upgrade --install ingress byjg/easyhaproxy \
+        --version $HELM_PACKAGE_VERSION \
         --namespace $NAMESPACE_PTR \
         --set resources.requests.cpu=100m \
         --set resources.requests.memory=128Mi \

--- a/addons/easyhaproxy/enable
+++ b/addons/easyhaproxy/enable
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+
+source $SNAP/actions/common/utils.sh
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+"$SNAP/microk8s-enable.wrapper" dns
+"$SNAP/microk8s-enable.wrapper" helm3
+
+
+NAMESPACE_PTR="easyhaproxy"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+echo "+=========================================+"
+echo "| Enabling EasyHAProxy Ingress Controller |"
+echo "+=========================================+"
+echo
+
+$KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
+
+$HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
+$HELM repo update > /dev/null 2>&1
+
+$KUBECTL label nodes $(hostname) "easyhaproxy/node=master" --overwrite
+
+if [ -z "$1" ]; then
+
+    $HELM upgrade --install ingress byjg/easyhaproxy \
+        --namespace $NAMESPACE_PTR \
+        --set resources.requests.cpu=100m \
+        --set resources.requests.memory=128Mi
+
+    echo
+    echo "Installed as a Daemonset at port 80 and 443"
+    echo
+
+elif [ "$1" == "--nodeport" ]; then
+
+    $HELM upgrade --install ingress byjg/easyhaproxy \
+        --namespace $NAMESPACE_PTR \
+        --set resources.requests.cpu=100m \
+        --set resources.requests.memory=128Mi \
+        --set service.create=true \
+        --set service.type=NodePort \
+        --set binding.ports.http=30080 \
+        --set binding.ports.https=30443 \
+        --set binding.ports.stats=31936
+
+    echo
+    echo "Installed as a Nodeport at port 30080 and 30443"
+    echo
+
+else
+
+    echo 
+    echo ERROR: Invalid parameter $1
+    echo 
+    echo "You should pass 'empty' to install as a daemonset or '--nodeport' to install as nodeport"
+    echo
+
+fi
+

--- a/addons/easyhaproxy/enable
+++ b/addons/easyhaproxy/enable
@@ -57,7 +57,7 @@ $HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
 $HELM repo update > /dev/null 2>&1
 
 $KUBECTL label nodes $(hostname) "easyhaproxy/node=master" --overwrite
-$HELM_PACKAGE_VERSION="0.1.5"
+HELM_PACKAGE_VERSION="0.1.5"
 
 if [ -z "$1" ]; then
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 sh
 PyYaml
+requests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 sh
+PyYaml

--- a/tests/test_easyhaproxy.py
+++ b/tests/test_easyhaproxy.py
@@ -23,7 +23,7 @@ class TestEasyHAProxy(object):
 
     def validate_easyhaproxy(self):
         """
-        Validate easyhaproxy
+        Validate easyhaproxy (2)
         """
         wait_for_pod_state(
             "", "easyhaproxy", "running", label="app.kubernetes.io/name=easyhaproxy"

--- a/tests/test_easyhaproxy.py
+++ b/tests/test_easyhaproxy.py
@@ -12,6 +12,12 @@ class TestEasyHAProxy(object):
     @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     def test_easyhaproxy(self):
         """
+        Disabling conflicting addons
+        """
+        microk8s_disable("ingress")
+        microk8s_disable("traefik")
+
+        """
         Sets up and validates easyhaproxy.
         """
         print("Enabling easyhaproxy")
@@ -23,7 +29,7 @@ class TestEasyHAProxy(object):
 
     def validate_easyhaproxy(self):
         """
-        Validate easyhaproxy (2)
+        Validate easyhaproxy
         """
         wait_for_pod_state(
             "", "easyhaproxy", "running", label="app.kubernetes.io/name=easyhaproxy"

--- a/tests/test_easyhaproxy.py
+++ b/tests/test_easyhaproxy.py
@@ -1,0 +1,30 @@
+import pytest
+import platform
+
+from utils import (
+    microk8s_disable,
+    microk8s_enable,
+    wait_for_pod_state,
+)
+
+
+class TestEasyHAProxy(object):
+    @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
+    def test_easyhaproxy(self):
+        """
+        Sets up and validates easyhaproxy.
+        """
+        print("Enabling easyhaproxy")
+        microk8s_enable("easyhaproxy")
+        print("Validating easyhaproxy")
+        self.validate_easyhaproxy()
+        print("Disabling easyhaproxy")
+        microk8s_disable("easyhaproxy")
+
+    def validate_easyhaproxy(self):
+        """
+        Validate easyhaproxy
+        """
+        wait_for_pod_state(
+            "", "easyhaproxy", "running", label="app.kubernetes.io/name=easyhaproxy"
+        )


### PR DESCRIPTION
This PR adds the EasyHAProxy add-on. 

EasyHAProxy can configure HAProxy automatically based on some labels and act as ingress. The great advantage on use HAProxy as ingress is that we can use provide TCP endpoints, which Nginx doesn't allow. 

To enable the add-on
```
microk8s enable easyhaproxy [--nodeport]
```

By default, enable it as a daemonset, but it can be changed by adding `--nodeport` when enable the add-on. 

More info about the add-on: 
https://github.com/byjg/docker-easy-haproxy

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
