### PR TITLE
Add Static Http Server Parking Addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -184,7 +184,7 @@ microk8s-addons:
 
     - name: "parking"
       description: "Static webserver to park a domain. Works with EasyHAProxy."
-      version: "latest"
+      version: "0.1.0"
       check_status: "deployment.apps/parking-static-httpserver"
       supported_architectures:
         - amd64

--- a/addons.yaml
+++ b/addons.yaml
@@ -181,3 +181,11 @@ microk8s-addons:
       confinement: "classic"
       supported_architectures:
         - amd64
+
+    - name: "parking"
+      description: "Static webserver to park a domain. Works with EasyHAProxy."
+      version: "latest"
+      check_status: "deployment.apps/parking-static-httpserver"
+      supported_architectures:
+        - amd64
+        - arm64

--- a/addons/parking/disable
+++ b/addons/parking/disable
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+source $SNAP/actions/common/utils.sh
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+
+NAMESPACE_PTR="parking"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+echo "Disabling Parking App"
+echo
+
+$HELM uninstall parking  \
+    --namespace $NAMESPACE_PTR
+
+# $KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true

--- a/addons/parking/enable
+++ b/addons/parking/enable
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+source $SNAP/actions/common/utils.sh
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+"$SNAP/microk8s-enable.wrapper" dns
+"$SNAP/microk8s-enable.wrapper" helm3
+
+
+NAMESPACE_PTR="parking"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+echo "+======================+"
+echo "| Enabling Parking App |"
+echo "+======================+"
+echo
+
+$KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
+
+$HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
+$HELM repo update > /dev/null 2>&1
+
+if [ -z "$1" ]; then
+
+    echo "ERROR: Missing Domain names"
+    echo
+    echo "You need to pass the domain names using comma and no spaces."
+    echo
+
+else
+
+    $HELM upgrade --install parking byjg/static-httpserver \
+        --namespace parking \
+        --set "ingress.hosts={$1}" \
+        --set parameters.title="Domain Parked" \
+        --set parameters.htmlTitle="Domain Parked"
+
+    echo
+    echo "Installed."
+    echo
+
+fi
+

--- a/addons/parking/enable
+++ b/addons/parking/enable
@@ -23,6 +23,8 @@ $KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
 $HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
 $HELM repo update > /dev/null 2>&1
 
+$HELM_PACKAGE_VERSION="0.1.0"
+
 if [ -z "$1" ]; then
 
     echo "ERROR: Missing Domain names"
@@ -33,6 +35,7 @@ if [ -z "$1" ]; then
 else
 
     $HELM upgrade --install parking byjg/static-httpserver \
+        --version $HELM_PACKAGE_VERSION \
         --namespace parking \
         --set "ingress.hosts={$1}" \
         --set parameters.title="Domain Parked" \

--- a/addons/parking/enable
+++ b/addons/parking/enable
@@ -23,7 +23,7 @@ $KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
 $HELM repo add byjg https://opensource.byjg.com/helm > /dev/null 2>&1
 $HELM repo update > /dev/null 2>&1
 
-$HELM_PACKAGE_VERSION="0.1.0"
+HELM_PACKAGE_VERSION="0.1.0"
 
 if [ -z "$1" ]; then
 

--- a/tests/test_parking.py
+++ b/tests/test_parking.py
@@ -1,0 +1,30 @@
+import pytest
+import platform
+
+from utils import (
+    microk8s_disable,
+    microk8s_enable,
+    wait_for_pod_state,
+)
+
+
+class TestParking(object):
+    @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
+    def test_parking(self):
+        """
+        Sets up and validates parking.
+        """
+        print("Enabling parking")
+        microk8s_enable("parking", optional_args="example.com")
+        print("Validating parking")
+        self.validate_parking()
+        print("Disabling parking")
+        microk8s_disable("parking")
+
+    def validate_parking(self):
+        """
+        Validate parking
+        """
+        wait_for_pod_state(
+            "", "parking", "running", label="app.kubernetes.io/name=static-httpserver"
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -172,7 +172,7 @@ def wait_for_namespace_termination(namespace, timeout_insec=360):
         time.sleep(10)
 
 
-def microk8s_enable(addon, timeout_insec=300):
+def microk8s_enable(addon, timeout_insec=300, optional_args=None):
     """
     Disable an addon
 
@@ -188,7 +188,7 @@ def microk8s_enable(addon, timeout_insec=300):
             print("Not a cuda capable system. Will not test gpu addon")
             raise CalledProcessError(1, "Nothing to do for gpu")
 
-    cmd = "/snap/bin/microk8s.enable {}".format(addon)
+    cmd = "/snap/bin/microk8s.enable {} {}".format(addon, optional_args or "")
     return run_until_success(cmd, timeout_insec)
 
 


### PR DESCRIPTION
This PR adds a Static Http Server Parking Addon with all necessary ingress, service and Pods. 
This Add-on also adds the proper labels that can be discovered by EasyHAProxy.

To enable this addon:
```
microk8s enable parking <domainlist>
```
The <domainlist> is the list of domains with comma to be set up on the EasyHAProxy ingress. 

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
