### PR TITLE
Add Shifu as a MicroK8s addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -198,3 +198,11 @@ microk8s-addons:
       supported_architectures:
         - amd64
         - arm64
+
+    - name: "shifu"
+      description: "Kubernetes native IoT software development framework."
+      version: "0.11.0"
+      check_status: "deployment.apps/shifu-crd-controller-manager"
+      supported_architectures:
+        - amd64
+        - arm64

--- a/addons/shifu/disable
+++ b/addons/shifu/disable
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+
+if [ -f "$SNAP_DATA/shifu/shifu_install.yml" ]
+then
+echo "Disabling Shifu"
+$KUBECTL delete -f "$SNAP_DATA/shifu/shifu_install.yml" || true
+run_with_sudo rm -rf "$SNAP_DATA/shifu"
+fi
+
+echo "The Shifu addon is disabled."

--- a/addons/shifu/enable
+++ b/addons/shifu/enable
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+
+do_prerequisites() {
+  # enable dns service
+  $SNAP/microk8s-enable.wrapper dns
+  $SNAP/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
+  run_with_sudo mkdir -p "$SNAP_DATA/shifu"
+}
+
+get_shifu() {
+  SHIFU_VERSION="v0.11.0"
+  echo "Fetching shifu version $SHIFU_VERSION."
+  fetch_as https://raw.githubusercontent.com/Edgenesis/shifu/$SHIFU_VERSION/pkg/k8s/crd/install/shifu_install.yml "$SNAP_DATA/shifu/shifu_install.yml"
+}
+
+enable_shifu() {
+  echo "Enabling Shifu"
+  $KUBECTL apply -f "$SNAP_DATA/shifu/shifu_install.yml"
+}
+
+do_prerequisites
+get_shifu
+enable_shifu
+
+echo "The Shifu is enabled."

--- a/tests/test-shifu.py
+++ b/tests/test-shifu.py
@@ -1,0 +1,36 @@
+import pytest
+import os
+import platform
+
+from utils import (
+    microk8s_disable,
+    microk8s_enable,
+    wait_for_pod_state,
+)
+
+
+class Testshifu(object):
+    @pytest.mark.skipif(
+        platform.machine() == "s390x",
+        reason="Not available on s390x")
+    def test_shifu(self):
+        """
+        Sets up and validates shifu.
+        """
+        print("Enabling shifu")
+        microk8s_enable("shifu")
+        print("Validating shifu")
+        self.validate_shifu()
+        print("Disabling shifu")
+        microk8s_disable("shifu")
+
+    def validate_shifu(self):
+        """
+        Validate shifu
+        """
+        wait_for_pod_state(
+            "",
+            "shifu-crd-system",
+            "running",
+            label="control-plane=controller-manager"
+        )

--- a/tests/test-shifu.py
+++ b/tests/test-shifu.py
@@ -10,9 +10,7 @@ from utils import (
 
 
 class Testshifu(object):
-    @pytest.mark.skipif(
-        platform.machine() == "s390x",
-        reason="Not available on s390x")
+    @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     def test_shifu(self):
         """
         Sets up and validates shifu.
@@ -29,8 +27,5 @@ class Testshifu(object):
         Validate shifu
         """
         wait_for_pod_state(
-            "",
-            "shifu-crd-system",
-            "running",
-            label="control-plane=controller-manager"
+            "", "shifu-crd-system", "running", label="control-plane=controller-manager"
         )


### PR DESCRIPTION
### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

Usage:

`microk8s enable shifu`

Description:

This PR adds https://github.com/Edgenesis/shifu as a MicroK8s addon. Shifu is a Kubernetes-native IoT development framework. Shifu virtualizes your device into a K8s pod, and expose its capabilities as APIs. Through this, Shifu transforms the traditional complex IoT APP development into modern web APP development. 

Shifu's vision: Making developing an IoT solution as simple as developing a web APP!

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
