### PR TITLE
[Backport] Bump trivy addon helm chart version to 0.15.1

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -131,7 +131,7 @@ microk8s-addons:
 
     - name: "trivy"
       description: "Kubernetes-native security scanner"
-      version: "0.2.0"
+      version: "0.15.1"
       check_status: "deployment.apps/trivy-operator"
       supported_architectures:
         - arm64

--- a/addons/trivy/enable
+++ b/addons/trivy/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_TRIVY="trivy-system"
 
-TRIVY_HELM_VERSION="0.2.0"
+TRIVY_HELM_VERSION="0.15.1"
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm3.wrapper"


### PR DESCRIPTION
Backport for https://github.com/canonical/microk8s-community-addons/pull/162

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
