### PR TITLE
Skip installing cilium binary in offline mode

### DIFF
--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -6,6 +6,27 @@ source $SNAP/actions/common/utils.sh
 
 "$SNAP/microk8s-enable.wrapper" helm3
 
+CILIUM_VERSION=""
+OFFLINE_MODE="False"
+
+# Parse command-line arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      CILIUM_VERSION="$2"
+      shift 2
+      ;;
+    --offline)
+      OFFLINE_MODE=True
+      shift
+      ;;
+    *)
+      echo "Invalid option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
 echo "Ensure kube-apiserver --allow-privileged=true flag"
 if ! grep -qE -- "--allow-privileged=true" "$SNAP_DATA/args/kube-apiserver"; then
   echo "Adding kube-apiserver --allow-privileged=true flag"
@@ -39,7 +60,6 @@ fi
 echo "Enabling Cilium"
 
 # Cilium Supports Arm beginning v1.11.12 and greater
-read -ra CILIUM_VERSION <<< "$1"
 if [ -z "$CILIUM_VERSION" ]; then
   CILIUM_VERSION="v1.13.4"
 fi
@@ -97,7 +117,7 @@ else
   "$SNAP/microk8s-kubectl.wrapper" -n $NAMESPACE rollout status ds/cilium
 
   # Skip installing the Cilium CLI binary if the cluster is in offline mode
-  if [[ "$*" != *"--offline"* ]]; then
+  if [[ "$OFFLINE_MODE" == False ]]; then
     # Fetch the Cilium CLI binary and install
     ARCH=$(arch)
     SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -125,4 +145,7 @@ else
   echo "In offline mode, the Cilium CLI binary will not be installed."
   echo "You can enable offline mode with:"
   echo "  sudo microk8s enable cilium --offline"
+  echo
+  echo "You can also specify a Cilium version with:"
+  echo "  sudo microk8s enable cilium --version <version>"
 fi

--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -96,8 +96,8 @@ else
   echo "Waiting for cilium. This may take several minutes."
   "$SNAP/microk8s-kubectl.wrapper" -n $NAMESPACE rollout status ds/cilium
 
-  # Check if we are online
-  if ping -q -c 1 -W 1 8.8.8.8 > /dev/null; then
+  # Skip installing the Cilium CLI binary if the cluster is in offline mode
+  if [[ "$*" != *"--offline"* ]]; then
     # Fetch the Cilium CLI binary and install
     ARCH=$(arch)
     SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -120,4 +120,9 @@ else
   echo "    --reuse-values \\"
   echo "    --set hubble.relay.enabled=true \\"
   echo "    --set hubble.ui.enabled=true"
+  echo
+  echo
+  echo "In offline mode, the Cilium CLI binary will not be installed."
+  echo "You can enable offline mode with:"
+  echo "  sudo microk8s enable cilium --offline"
 fi

--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -119,6 +119,7 @@ else
   # Skip installing the Cilium CLI binary if the cluster is in offline mode
   if [[ "$OFFLINE_MODE" == False ]]; then
     # Fetch the Cilium CLI binary and install
+    echo "Installing Cilium CLI binary"
     ARCH=$(arch)
     SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
     mkdir -p "${SCRIPT_DIR}/cli/"

--- a/addons/cilium/enable
+++ b/addons/cilium/enable
@@ -96,20 +96,28 @@ else
   echo "Waiting for cilium. This may take several minutes."
   "$SNAP/microk8s-kubectl.wrapper" -n $NAMESPACE rollout status ds/cilium
 
-  # Fetch the Cilium CLI binary and install
-  ARCH=$(arch)
-  SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-  mkdir -p "${SCRIPT_DIR}/cli/"
-  fetch_as "https://github.com/cilium/cilium-cli/releases/download/v0.15.2/cilium-linux-${ARCH}.tar.gz" "${SCRIPT_DIR}/cli/cilium.tar.gz"
-  tar -zxf "${SCRIPT_DIR}/cli/cilium.tar.gz" -C "${SCRIPT_DIR}/cli"
-  chmod +x "${SCRIPT_DIR}/cli/cilium"
-  cp "${SCRIPT_DIR}/cilium" "${SNAP_COMMON}/plugins/cilium"
-  chmod +x "${SNAP_COMMON}/plugins/cilium"
+  # Check if we are online
+  if ping -q -c 1 -W 1 8.8.8.8 > /dev/null; then
+    # Fetch the Cilium CLI binary and install
+    ARCH=$(arch)
+    SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+    mkdir -p "${SCRIPT_DIR}/cli/"
+    fetch_as "https://github.com/cilium/cilium-cli/releases/download/v0.15.2/cilium-linux-${ARCH}.tar.gz" "${SCRIPT_DIR}/cli/cilium.tar.gz"
+    tar -zxf "${SCRIPT_DIR}/cli/cilium.tar.gz" -C "${SCRIPT_DIR}/cli"
+    chmod +x "${SCRIPT_DIR}/cli/cilium"
+    cp "${SCRIPT_DIR}/cilium" "${SNAP_COMMON}/plugins/cilium"
+    chmod +x "${SNAP_COMMON}/plugins/cilium"
+  else
+    echo "Cluster is in offline mode. Skipping installing Cilium binary."
+  fi
 
   echo "Cilium is enabled"
   echo
-  echo "You can now enable hubble with:"
-  echo "  sudo microk8s cilium hubble enable"
-
+  echo "You can now enable hubble relay and UI with:"
+  echo "  sudo microk8s helm3 upgrade cilium cilium/cilium \\"
+  echo "    --version ${CILIUM_VERSION} \\"
+  echo "    --namespace ${NAMESPACE} \\"
+  echo "    --reuse-values \\"
+  echo "    --set hubble.relay.enabled=true \\"
+  echo "    --set hubble.ui.enabled=true"
 fi
-


### PR DESCRIPTION
When deploying in offline mode, we now skip installing the cilium binary. We introduce a new flag `--offline` to deploy cilium in offline mode.
We also prompt the user to use helm to enable hubble instead of the cli. 

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
