### PR TITLE
Remove automatic kata snap install and set default runtime path

### DIFF
--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -16,10 +16,11 @@ def mark_kata_enabled():
     try:
         snapdata_path = os.environ.get("SNAP_DATA")
         lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
-        subprocess.call(['sudo', 'touch', lock_fname])
-    except (subprocess.CalledProcessError):
-        print("Failed to mark the kata addon as enabled." )
+        subprocess.call(["sudo", "touch", lock_fname])
+    except subprocess.CalledProcessError:
+        print("Failed to mark the kata addon as enabled.")
         sys.exit(4)
+
 
 def apply_runtime_manifest():
     """
@@ -29,9 +30,11 @@ def apply_runtime_manifest():
         snap_path = os.environ.get("SNAP")
         current_path = os.path.dirname(os.path.realpath(__file__))
         manifest = "{}/kata/runtime.yaml".format(current_path)
-        subprocess.call(["{}/microk8s-kubectl.wrapper".format(snap_path), "apply", "-f", manifest])
-    except (subprocess.CalledProcessError):
-        print("Failed to apply the runtime manifest." )
+        subprocess.call(
+            ["{}/microk8s-kubectl.wrapper".format(snap_path), "apply", "-f", manifest]
+        )
+    except subprocess.CalledProcessError:
+        print("Failed to apply the runtime manifest.")
         sys.exit(5)
 
 
@@ -41,9 +44,13 @@ def restart_containerd():
     """
     try:
         print("Restarting containerd")
-        subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
-    except (subprocess.CalledProcessError):
-        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually." )
+        subprocess.call(
+            ["sudo", "systemctl", "restart", "snap.microk8s.daemon-containerd"]
+        )
+    except subprocess.CalledProcessError:
+        print(
+            "Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually."
+        )
         sys.exit(3)
 
 
@@ -53,13 +60,13 @@ def configure_containerd(kata_path):
     """
     snapdata_path = os.environ.get("SNAP_DATA")
     containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
-    #Create temp file
+    # Create temp file
     fh, abs_path = mkstemp()
-    with fdopen(fh,'w') as tmp_file:
+    with fdopen(fh, "w") as tmp_file:
         with open(containerd_env_file) as conf_file:
             for line in conf_file:
                 if "KATA_PATH=" in line:
-                  line = "KATA_PATH=\"{}\"\n".format(kata_path)
+                    line = 'KATA_PATH="{}"\n'.format(kata_path)
                 tmp_file.write(line)
 
     copymode(containerd_env_file, abs_path)
@@ -87,7 +94,7 @@ def print_next_steps():
 @click.command()
 @click.option(
     "--runtime-path",
-    default=None,
+    default="/opt/kata/bin",
     help="The path to the kata container runtime binaries.",
 )
 def kata(runtime_path):
@@ -95,29 +102,16 @@ def kata(runtime_path):
     Enable the kata runtime. Either snap install the kata binaries or use a path to already deployed
     kata binaries. Note the kata binary must be called kata-runtime
     """
-    if not runtime_path:
-        try:
-            print("Installing kata-containers snap")
-            subprocess.call(['sudo', 'snap', 'install', 'kata-containers', '--classic'])
-            kata_path = "/snap/kata-containers/current/usr/bin/"
-        except (subprocess.CalledProcessError):
-            print("Failed to install kata-containers snap.")
-            print("Use the --runtime-path argument to point to the kata containers runtime binaries.")
-            sys.exit(1)
-    else:
-        kata_path = runtime_path
-
-    if not os.path.exists("{}/kata-runtime".format(kata_path)):
-        print("Kata runtime binaries was not found under {}.".format(kata_path))
+    if not os.path.exists("{}/kata-runtime".format(runtime_path)):
+        print("Kata runtime binaries was not found under {}.".format(runtime_path))
         print("Use the --runtime-path argument to point to the right location.")
         sys.exit(2)
 
-    configure_containerd(kata_path)
+    configure_containerd(runtime_path)
     restart_containerd()
     apply_runtime_manifest()
     mark_kata_enabled()
     print_next_steps()
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Black formatting fixes and dropped the kata snap package usage, and the default runtime path is set to `/opt/kata/bin/`