### PR TITLE
Fix typo and documentation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -87,13 +87,16 @@ The `disable` script is called when running `microk8s disable demo-nginx`.
 # addons/demo-nginx/disable
 
 import click
+import os
 import subprocess
+
+KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
 
 @click.command()
 def main():
     click.echo("Disabling demo-nginx")
     subprocess.check_call([
-        "microk8s", "kubectl", "delete", "deploy", "demo-nginx"
+        KUBECTL, "delete", "deploy", "demo-nginx"
     ])
     click.echo("Disabled demo-nginx")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -174,7 +174,7 @@ def wait_for_namespace_termination(namespace, timeout_insec=360):
 
 def microk8s_enable(addon, timeout_insec=300, optional_args=None):
     """
-    Disable an addon
+    Enable an addon
 
     Args:
         addon: name of the addon
@@ -194,7 +194,7 @@ def microk8s_enable(addon, timeout_insec=300, optional_args=None):
 
 def microk8s_disable(addon):
     """
-    Enable an addon
+    Disable an addon
 
     Args:
         addon: name of the addon


### PR DESCRIPTION
* The function docs in `tests/utils.py` were swapped.
* Running the `disable` as defined in the current `HACKING.md` caused a `FilenNotFound` error for `microK8s`. Using the direct wrapper as in `enable` fixes this.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
