### PR TITLE
Pin versions of KWasm operator and node installer

### DIFF
--- a/addons/kwasm/enable
+++ b/addons/kwasm/enable
@@ -3,6 +3,8 @@
 set -e
 
 NAMESPACE_KWASM="kwasm-system"
+OPERATOR_VERSION="0.2.2"
+INSTALLER_VERSION="v0.2.0"
 
 "$SNAP/microk8s-enable.wrapper" helm3
 HELM="$SNAP/microk8s-helm3.wrapper"
@@ -11,9 +13,13 @@ echo "Installing KWasm"
 
 $HELM repo add --force-update kwasm http://kwasm.sh/kwasm-operator/ 
 $HELM upgrade -i -n $NAMESPACE_KWASM --create-namespace kwasm-operator kwasm/kwasm-operator \
+    --version $OPERATOR_VERSION \
+    --set kwasmOperator.installerImage="ghcr.io/kwasm/kwasm-node-installer:$INSTALLER_VERSION" \
     --set kwasmOperator.autoProvision="true"
 
-echo "KWasm is installed"
+echo "KWasm is installed with the following versions:"
+echo "  kwasm-operator: $OPERATOR_VERSION"
+echo "  kwasm-node-installer: $INSTALLER_VERSION"
 echo ""
 echo "If you need help to get started visit:"
 echo "    https://kwasm.sh/?dist=microk8s#Quickstart"


### PR DESCRIPTION
This PR sets fix versions for KWasm operator and node installer as follows:

OPERATOR_VERSION="0.2.2"
INSTALLER_VERSION="v0.2.0"

related issue: #180

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
