### PR TITLE
Update KWasm installer version to 0.3.0

### DIFF
--- a/addons/kwasm/enable
+++ b/addons/kwasm/enable
@@ -3,6 +3,8 @@
 set -e
 
 NAMESPACE_KWASM="kwasm-system"
+OPERATOR_VERSION="0.2.2"
+INSTALLER_VERSION="v0.3.0"
 
 "$SNAP/microk8s-enable.wrapper" helm3
 HELM="$SNAP/microk8s-helm3.wrapper"
@@ -11,9 +13,13 @@ echo "Installing KWasm"
 
 $HELM repo add --force-update kwasm http://kwasm.sh/kwasm-operator/ 
 $HELM upgrade -i -n $NAMESPACE_KWASM --create-namespace kwasm-operator kwasm/kwasm-operator \
+    --version $OPERATOR_VERSION \
+    --set kwasmOperator.installerImage="ghcr.io/kwasm/kwasm-node-installer:$INSTALLER_VERSION" \
     --set kwasmOperator.autoProvision="true"
 
-echo "KWasm is installed"
+echo "KWasm is installed with the following versions:"
+echo "  kwasm-operator: $OPERATOR_VERSION"
+echo "  kwasm-node-installer: $INSTALLER_VERSION"
 echo ""
 echo "If you need help to get started visit:"
 echo "    https://kwasm.sh/?dist=microk8s#Quickstart"

--- a/tests/templates/wasm-job.yaml
+++ b/tests/templates/wasm-job.yaml
@@ -1,8 +1,8 @@
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: crun
-handler: crun
+  name: wasmedge
+handler: wasmedge
 ---
 apiVersion: batch/v1
 kind: Job
@@ -10,13 +10,10 @@ metadata:
   name: wasm-test
 spec:
   template:
-    metadata:
-      annotations:
-        module.wasm.image/variant: compat-smart
     spec:
       containers:
       - image: wasmedge/example-wasi:latest
         name: wasm-test
       restartPolicy: Never
-      runtimeClassName: crun
+      runtimeClassName: wasmedge
   backoffLimit: 1


### PR DESCRIPTION
This PR updates the installer version used by the KWasm operator to 0.3.0. 
This removes the `crun` runtime in favor of the wasmedge shim as a drop-in replacement.

However, the need to change the `RuntimeClass` makes this a breaking change.

related issue: https://github.com/canonical/microk8s-community-addons/issues/180

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
