### PR TITLE
Added Falco to microk8s community addons

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -225,3 +225,11 @@ microk8s-addons:
       supported_architectures:
         - amd64
         - arm64
+
+    - name: "falco"
+      description: "Cloud-native runtime threat detection tool for Linux and K8s"
+      version: "3.7.1"
+      check_status: "daemonset.apps/falco"
+      supported_architectures:
+        - amd64
+        - arm64

--- a/addons/falco/disable
+++ b/addons/falco/disable
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+NAMESPACE_FALCO="falco"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+KUBECTL_DELETE_ARGS="--wait=true --timeout=180s --ignore-not-found=true"
+
+echo "Disabling Falco"
+
+$HELM delete falco -n $NAMESPACE_FALCO
+
+$KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_FALCO" > /dev/null 2>&1 || true
+
+echo "Falco disabled"

--- a/addons/falco/enable
+++ b/addons/falco/enable
@@ -15,6 +15,8 @@ do_prerequisites() {
   "$SNAP/microk8s-enable.wrapper" helm3
   # enable dns service
   "$SNAP/microk8s-enable.wrapper" dns
+  # enable hostpath-storage
+  "$SNAP/microk8s-enable.wrapper" hostpath-storage
   # Allow some time for the apiserver to start
   sleep 5
   ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null

--- a/addons/falco/enable
+++ b/addons/falco/enable
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+NAMESPACE_FALCO="falco"
+
+FALCO_HELM_VERSION="3.7.1"
+
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+HELM="$SNAP/microk8s-helm3.wrapper"
+
+do_prerequisites() {
+  "$SNAP/microk8s-enable.wrapper" helm3
+  # enable dns service
+  "$SNAP/microk8s-enable.wrapper" dns
+  # Allow some time for the apiserver to start
+  sleep 5
+  ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
+}
+
+VALUES=""
+
+get_falco() {
+  # get the options
+  while getopts ":f:h:" flag; do
+    case "${flag}" in
+            f) VALUES=${OPTARG}
+              ;;
+            *) echo "Usage: microk8s enable falco"
+              echo ""
+              echo "With overwriting default values: microk8s enable falco -f values.yaml"
+              echo ""
+              echo "See https://github.com/falcosecurity/charts/tree/master/falco for more information about the values"
+              exit 0
+              ;;
+    esac
+  done
+
+  echo "Installing Falco"
+
+  if [ -n "$VALUES" ]; then
+      echo "Using values file: $VALUES"
+  fi
+
+  # make sure the "falco" namespace exists
+  # $KUBECTL create namespace "$NAMESPACE_FALCO" > /dev/null 2>&1 || true
+
+  # add the falcosecurity chart repository
+  $HELM repo add falcosecurity https://falcosecurity.github.io/charts
+
+  # install the helm chart
+  if [ -z "$VALUES" ]
+  then
+      $HELM upgrade -i falco falcosecurity/falco \
+        --namespace "$NAMESPACE_FALCO" \
+        --create-namespace \
+        --version $FALCO_HELM_VERSION \
+        --set driver.kind="modern-bpf" \
+        --set collectors.containerd.socket="/var/snap/microk8s/common/run/containerd.sock" \
+        --set falcosidekick.enabled=true \
+        --set falcosidekick.replicaCount=1 \
+        --set falcosidekick.webui.enabled=true \
+        --set falcosidekick.webui.replicaCount=1
+  else
+      $HELM upgrade -i falco falcosecurity/falco \
+        --namespace "$NAMESPACE_FALCO" \
+        --create-namespace \
+        --version $FALCO_HELM_VERSION \
+        -f $VALUES
+  fi
+
+  echo "Falco is installed"
+  echo "The default username/password for the Falcosidekick UI is admin/admin"
+}
+
+do_prerequisites
+get_falco

--- a/tests/test_falco.py
+++ b/tests/test_falco.py
@@ -1,0 +1,40 @@
+import pytest
+import os
+import platform
+
+from utils import (
+    microk8s_disable,
+    microk8s_enable,
+    wait_for_pod_state,
+)
+
+class TestFalco(object):
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="Falco tests are only relevant in x86 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping falco tests as we are under time pressure",
+    )
+    def test_falco(self):
+        """
+        Sets up and validates Falco.
+        """
+        print("Enabling Falco")
+        microk8s_enable("falco")
+        print("Validating Falco")
+        self.validate_falco()
+        print("Disabling Falco")
+        microk8s_disable("falco")
+
+    def validate_falco(self):
+        """
+        Validate Falco
+        """
+        wait_for_pod_state(
+            "",
+            "falco",
+            "running",
+            label="app.kubernetes.io/instance=falco",
+        )


### PR DESCRIPTION
### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

I am adding Falco (https://falco.org/) which is a CNCF Incubating Project for runtime threat detection/security of Kubernetes to the community addons for microk8s. I mirrored the Trivy add-on for inspiration (also Helm-based) so this should work the same as that existing one.