### PR TITLE
fix(portainer): update the check status to only target portainer serv…

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -86,7 +86,7 @@ microk8s-addons:
     - name: "portainer"
       description: "Portainer UI for your Kubernetes cluster"
       version: "2.0.0"
-      check_status: "pod/portainer"
+      check_status: "deployment.apps/portainer "
       supported_architectures:
         - arm64
         - amd64


### PR DESCRIPTION
Backport #166 

Update the check_status for Portainer to match for only a Portainer server installation, and not a Portainer agent installation.

#Fixes 165