### PR TITLE
Bump sosivio timeout to 600 seconds

### DIFF
--- a/addons/sosivio/enable
+++ b/addons/sosivio/enable
@@ -22,7 +22,7 @@ DASHBOARD_SERVICE="dashboard-lb"
 HELM_REPO_URL="https://helm.sosiv.io"
 HELM_REPO_NAME="sosivio"
 HELM_VERSION="1.7.1"
-WAIT_SECONDS=300
+WAIT_SECONDS=600
 DEBUG=0
 
 usage () {
@@ -106,7 +106,7 @@ wait_for_sosivio () {
   start_time=$(date +'%s')
   until $WATCH deploy -n ${NAMESPACE_SOSIVIO} sosivio-dashboard --watch > /dev/null 2>&1
   do
-    if [ $(( $start_time + $WAIT_SECONDS )) -lt $(date +'%s') ] ; 
+    if [ $(( $start_time + $WAIT_SECONDS )) -lt $(date +'%s') ] ;
     then
         echo "sosivio wait time exceeded ($WAIT_SECONDS seconds)"
         echo "please check your internet connection or run again with '-w' flag."


### PR DESCRIPTION
### Summary

Tackles the following issue in CI

```
tests/test_sosivio.py Enabling sosivio
Sosivio Version 1.7.1
hint: use -v flag to set a different version. (ex - microk8s enable sosivio -v x.y.z)

Enabling Sosivio


Waiting for Sosivio to become active...
It might take a while if your network connection is slow.
sosivio wait time exceeded (300 seconds)
please check your internet connection or run again with '-w' flag.
check 'microk8s enable sosivio -h' for more details

note: sosivio is still getting deployed, you can check if all the pods are running using:
microk8s kubectl get pods -n sosivio
F
```