### PR TITLE
[Backport 1.28] Fix spelling errors (#196)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributor Guide
 
-MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contibutions for code, add-ons, suggestions and documentation. Many of the features currently part of MicroK8s originated in the community, and we are very keen for that to continue. This page details a few notes, workflows and suggestions for how to make contributions most effective and help us all build a better MicroK8s for everyone - please give them a read before working on any contributions.
+MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contributions for code, add-ons, suggestions and documentation. Many of the features currently part of MicroK8s originated in the community, and we are very keen for that to continue. This page details a few notes, workflows and suggestions for how to make contributions most effective and help us all build a better MicroK8s for everyone - please give them a read before working on any contributions.
 
 ## Licensing
 

--- a/addons/multus/multus.yaml
+++ b/addons/multus/multus.yaml
@@ -26,8 +26,8 @@ spec:
           properties:
             apiVersion:
               description: |
-                APIVersion defines the versioned schema of this represen
-                tation of an object. Servers should convert recognized schemas to the
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the
                 latest internal value, and may reject unrecognized values. More info:
                 https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string


### PR DESCRIPTION
### Summary

Backport #196 typo fixes to 1.28 branch