### PR TITLE
Update on Istio addon to specify the version to install

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -19,7 +19,7 @@ microk8s-addons:
 
     - name: "istio"
       description: "Core Istio service mesh services"
-      version: "1.18.2"
+      version: "1.20.0"
       check_status: "${SNAP_DATA}/bin/istioctl"
       supported_architectures:
         - amd64

--- a/addons/istio/disable
+++ b/addons/istio/disable
@@ -4,9 +4,13 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
+
 echo "Disabling Istio"
 
-run_with_sudo "${SNAP_DATA}/bin/istioctl" -c "${SNAP_DATA}/credentials/client.config" x uninstall --purge -y
+run_with_sudo "${SNAP_DATA}/bin/istioctl" -c "${SNAP_DATA}/credentials/client.config" uninstall --purge -y
+run_with_sudo "${KUBECTL}" delete namespace istio-system > /dev/null 2>&1 || true
+
 run_with_sudo rm -rf "${SNAP_DATA}/bin/istioctl"
 run_with_sudo rm -rf "$SNAP_USER_COMMON/istio-auth.lock"
 run_with_sudo rm -rf "$SNAP_USER_COMMON/istio.lock"

--- a/addons/istio/enable
+++ b/addons/istio/enable
@@ -4,28 +4,124 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Enabling Istio"
+# pod/servicegraph will start failing without dns
+"$SNAP/microk8s-enable.wrapper" dns
+
+ISTIO_LATEST=$(curl https://api.github.com/repos/istio/istio/tags 2>/dev/null | jq '.[0].name' | sed 's/"//g')
+
+#Takes one parameter to chek if the version exists
+check_version() { 
+
+    local version="$1"
+    local versions=$(curl https://api.github.com/repos/istio/istio/tags 2>/dev/null | jq '.[].name')
+    local istio_versions=(${versions//\"/})
+
+    for item in "${istio_versions[@]}"; do
+        #echo $item
+        if [ "$item" == "$version" ]; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+# Display every Istio version
+display_versions(){
+    echo "Available Istio versions:"
+    echo ""
+    curl https://api.github.com/repos/istio/istio/tags 2>/dev/null | jq '.[].name'
+}
+# Function to display usage
+display_usage() {
+    echo "Usage: microk8s enable istio [--istio-version <VERSION>]"
+    echo "Options:"
+    echo "  --istio-version <VERSION>   Specify the Istio version (default: $ISTIO_LATEST)"
+    exit 1
+}
+# set the Istio version provided by the user
+set_version (){
+
+    if [ $# -eq 0 ]; then
+        display_usage
+    fi
+
+
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+
+        case $key in
+            --istio-version)
+                ISTIO_VERSION="$2"
+                shift;shift 
+                check_version "$ISTIO_VERSION"
+
+                if [[ $? -eq 0 ]]; then
+                    echo ${bold}Specified version not available${normal}
+                    display_versions
+                    ISTIO_VERSION="$ISTIO_LATEST"
+
+                fi
+                ;;
+            *)
+                # unknown option
+                display_usage
+                ;;
+        esac
+    done
+
+    # Set Istio version to latest if not provided
+    if [ -z "$ISTIO_VERSION" ]; then
+        ISTIO_VERSION="$ISTIO_LATEST"
+    fi
+}
+
+set_version "$@"
+
+echo "Enabling Istio version: $ISTIO_VERSION"
 
 if [ ! -f "${SNAP_DATA}/bin/istioctl" ]
 then
-  ISTIO_VERSION="v1.18.2"
-  echo "Fetching istioctl version $ISTIO_VERSION."
-  ISTIO_ERSION=$(echo $ISTIO_VERSION | sed 's/v//g')
+
+  echo "Fetching istioctl version $ISTIO_VERSION ..."
+
   run_with_sudo mkdir -p "${SNAP_DATA}/tmp/istio"
   (cd "${SNAP_DATA}/tmp/istio"
-  fetch_as https://github.com/istio/istio/releases/download/${ISTIO_ERSION}/istio-${ISTIO_ERSION}-linux-amd64.tar.gz "$SNAP_DATA/tmp/istio/istio.tar.gz"
+  fetch_as https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz "$SNAP_DATA/tmp/istio/istio.tar.gz"
   run_with_sudo gzip -q -d "$SNAP_DATA/tmp/istio/istio.tar.gz"
   run_with_sudo tar -xvf "$SNAP_DATA/tmp/istio/istio.tar"
-  run_with_sudo chmod 777 "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}")
+  run_with_sudo chmod 777 "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}")
   run_with_sudo mkdir -p "$SNAP_DATA/bin/"
-  run_with_sudo mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}/bin/istioctl" "$SNAP_DATA/bin/"
+  run_with_sudo mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}/bin/istioctl" "$SNAP_DATA/bin/"
   run_with_sudo chmod +x "$SNAP_DATA/bin/"
 
   run_with_sudo rm -rf "$SNAP_DATA/tmp/istio"
+
+else
+  echo "istioctl is already available"
+  echo "Uninstalling the previous version and installing the $ISTIO_VERSION version"
+
+  run_with_sudo "${SNAP_DATA}/bin/istioctl" -c "${SNAP_DATA}/credentials/client.config" x uninstall --purge -y
+  run_with_sudo rm -rf "${SNAP_DATA}/bin/istioctl"
+  run_with_sudo rm -rf "$SNAP_USER_COMMON/istio-auth.lock"
+  run_with_sudo rm -rf "$SNAP_USER_COMMON/istio.lock"
+
+  echo "Fetching istioctl version $ISTIO_VERSION ..."
+
+  run_with_sudo mkdir -p "${SNAP_DATA}/tmp/istio"
+  (cd "${SNAP_DATA}/tmp/istio"
+  fetch_as https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz "$SNAP_DATA/tmp/istio/istio.tar.gz"
+  run_with_sudo gzip -q -d "$SNAP_DATA/tmp/istio/istio.tar.gz"
+  run_with_sudo tar -xvf "$SNAP_DATA/tmp/istio/istio.tar"
+  run_with_sudo chmod 777 "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}")
+  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
+  run_with_sudo mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}/bin/istioctl" "$SNAP_DATA/bin/"
+  run_with_sudo chmod +x "$SNAP_DATA/bin/"
+
+  run_with_sudo rm -rf "$SNAP_DATA/tmp/istio"
+
 fi
 
-# pod/servicegraph will start failing without dns
-"$SNAP/microk8s-enable.wrapper" dns
+
 
 run_with_sudo "$SNAP_DATA/bin/istioctl" -c "${SNAP_DATA}/credentials/client.config" install --set profile=demo -y
 

--- a/addons/istio/enable
+++ b/addons/istio/enable
@@ -7,23 +7,24 @@ source $SNAP/actions/common/utils.sh
 # pod/servicegraph will start failing without dns
 "$SNAP/microk8s-enable.wrapper" dns
 
+
 ISTIO_LATEST=$(curl https://api.github.com/repos/istio/istio/tags 2>/dev/null | jq '.[0].name' | sed 's/"//g')
 
 #Takes one parameter to chek if the version exists
 check_version() { 
-
     local version="$1"
     local versions=$(curl https://api.github.com/repos/istio/istio/tags 2>/dev/null | jq '.[].name')
     local istio_versions=(${versions//\"/})
 
     for item in "${istio_versions[@]}"; do
-        #echo $item
         if [ "$item" == "$version" ]; then
-            return 1
+            version_out=1
+            return
         fi
     done
 
-    return 0
+    version_out=0
+    return
 }
 # Display every Istio version
 display_versions(){
@@ -42,9 +43,8 @@ display_usage() {
 set_version (){
 
     if [ $# -eq 0 ]; then
-        display_usage
+      ISTIO_VERSION="$ISTIO_LATEST"
     fi
-
 
     while [[ $# -gt 0 ]]; do
         key="$1"
@@ -55,11 +55,12 @@ set_version (){
                 shift;shift 
                 check_version "$ISTIO_VERSION"
 
-                if [[ $? -eq 0 ]]; then
-                    echo ${bold}Specified version not available${normal}
+                if [[ $version_out -eq 0 ]]; then
+                    echo "Specified version not available"
                     display_versions
-                    ISTIO_VERSION="$ISTIO_LATEST"
-
+                    
+                    echo "Aborting Istio installation: Use one of the versions listed above"
+                    exit 0
                 fi
                 ;;
             *)
@@ -75,35 +76,13 @@ set_version (){
     fi
 }
 
+echo "Enabling Istio version: $ISTIO_VERSION"
+
 set_version "$@"
 
-echo "Enabling Istio version: $ISTIO_VERSION"
 
 if [ ! -f "${SNAP_DATA}/bin/istioctl" ]
 then
-
-  echo "Fetching istioctl version $ISTIO_VERSION ..."
-
-  run_with_sudo mkdir -p "${SNAP_DATA}/tmp/istio"
-  (cd "${SNAP_DATA}/tmp/istio"
-  fetch_as https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz "$SNAP_DATA/tmp/istio/istio.tar.gz"
-  run_with_sudo gzip -q -d "$SNAP_DATA/tmp/istio/istio.tar.gz"
-  run_with_sudo tar -xvf "$SNAP_DATA/tmp/istio/istio.tar"
-  run_with_sudo chmod 777 "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}")
-  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
-  run_with_sudo mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_VERSION}/bin/istioctl" "$SNAP_DATA/bin/"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/"
-
-  run_with_sudo rm -rf "$SNAP_DATA/tmp/istio"
-
-else
-  echo "istioctl is already available"
-  echo "Uninstalling the previous version and installing the $ISTIO_VERSION version"
-
-  run_with_sudo "${SNAP_DATA}/bin/istioctl" -c "${SNAP_DATA}/credentials/client.config" x uninstall --purge -y
-  run_with_sudo rm -rf "${SNAP_DATA}/bin/istioctl"
-  run_with_sudo rm -rf "$SNAP_USER_COMMON/istio-auth.lock"
-  run_with_sudo rm -rf "$SNAP_USER_COMMON/istio.lock"
 
   echo "Fetching istioctl version $ISTIO_VERSION ..."
 

--- a/tests/test_istio.py
+++ b/tests/test_istio.py
@@ -25,7 +25,7 @@ class TestIstio(object):
         Sets up and validate istio.
         """
         print("Enabling Istio")
-        microk8s_enable("istio")
+        microk8s_enable("istio",300, optional_args="--istio-version 1.20.0")
         print("Validating Istio")
         self.validate_istio()
         print("Disabling Istio")


### PR DESCRIPTION
## Update on Istio addon to specify the version to install

### Problem addresed
This update targets #152 where an update on the Istio version is requested and a way to select the version wanted.

### Solution
- By adding the flag ```--istio-version```  when enabling the addon you can choose a version between the available ones.
- The command checks for the official Istio releases and if not available it aborts the operation.
- If the flag is not set it will enable the latest version available.

### Other changes
- Updated the disable script.
- Updated unit test.

### Command structure
```shell
microk8s enable istio --istio-version 19.0.0
```

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
