### PR TITLE
Argument handling added to specifiy version of cloudnative-pg package

### DIFF
--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-CNPG_VERSION="1.21.1"
+CNPG_VERSION="$1"
+if [ -z "$1" ]; then
+        CNPG_VERSION="1.22.0"
 
 KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
 # shellcheck source=/dev/null


### PR DESCRIPTION
Handling of the first optional passed argument added, defining the version of the cloundnative-pg package which should be installed

Unfortunately, I couldn't test the code snippet.


Issue 217: [Update cloudnative-pg addon to version 1.22.0 and add addon arg to specifiy version](https://github.com/canonical/microk8s-community-addons/issues/217)

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
