### PR TITLE
cloudnative-pg: argument handling added to specifiy version of package and fixes

### DIFF
--- a/addons/cloudnative-pg/disable
+++ b/addons/cloudnative-pg/disable
@@ -19,6 +19,7 @@ cnpg_disable() {
 		exit 1
 	fi
 
+        rm -f "${SNAP_DATA}/bin/kubectl-cnpg"
 	echo "CloudNativePG uninstalled"
 }
 

--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-CNPG_VERSION="1.21.1"
+CNPG_VERSION="$1"
+if [ -z "$1" ]; then
+        CNPG_VERSION="1.22.0"
+fi
 
 KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
 # shellcheck source=/dev/null

--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -98,11 +98,12 @@ cnpg_enable() {
 	cnpg_apply_manifest
 	if [[ $? -ne 0 ]]; then
 	 echo "CloudNativePG not installed"
+         run_with_sudo rm -f "${SNAP_DATA}/bin/kubectl-cnpg"
 	 exit 1
 	fi
 
 	cnpg_show_first_cluster
-	cnpg_more_information "$cnpg_version"
+	cnpg_more_information "${CNPG_VERSION}"
 
 	echo "CloudNativePG installed"
 }


### PR DESCRIPTION
**Second try:**

Handling of the first optional passed argument added, defining the version of the cloundnative-pg package which should be installed

Issue 127: [Update cloudnative-pg addon to version 1.22.0 and add addon arg to specifiy version](https://github.com/canonical/microk8s-community-addons/issues/217)

I tested it right now on a MicroK8s v1.29 instance and added also some fixes for minor issues (look at commits).


*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
