### PR TITLE
chore: update cloudnative-pg default version

### DIFF
--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -3,7 +3,7 @@ set -e
 
 CNPG_VERSION="$1"
 if [ -z "$1" ]; then
-        CNPG_VERSION="1.22.0"
+        CNPG_VERSION="1.22.2"
 fi
 
 KUBECTL="${SNAP}/microk8s-kubectl.wrapper"


### PR DESCRIPTION
The new default version for CloudNativePG is 1.22.2

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
