### PR TITLE
Cloudnative-pg change to server-side apply and upgrade default version to 1.23.1

### DIFF
--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -3,7 +3,7 @@ set -e
 
 CNPG_VERSION="$1"
 if [ -z "$1" ]; then
-        CNPG_VERSION="1.22.0"
+        CNPG_VERSION="1.23.1"
 fi
 
 KUBECTL="${SNAP}/microk8s-kubectl.wrapper"

--- a/addons/cloudnative-pg/enable
+++ b/addons/cloudnative-pg/enable
@@ -39,7 +39,7 @@ cnpg_install_plugin() {
 }
 
 cnpg_apply_manifest() {
-	apply_wait=$("${SNAP_DATA}"/bin/kubectl-cnpg install generate | $KUBECTL apply -f - > /dev/null)
+	apply_wait=$("${SNAP_DATA}"/bin/kubectl-cnpg install generate | $KUBECTL apply --server-side -f - > /dev/null)
 
 	# If the apply isn't successful we stop and exit
 	if [[ "${apply_wait}" -ne 0 ]]; then


### PR DESCRIPTION
Accoding to the [change notes of cloudnative-pg version 1.22.2](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/release_notes/v1.22.md#changes), server-side apply is required to avoid this error at installation: 
`The CustomResourceDefinition "poolers.postgresql.cnpg.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

[Issue described on cloudnative-pg](https://github.com/cloudnative-pg/cloudnative-pg/issues/4377)

By the way we also upgraded the default version of cloudnative-pg to current version 1.23.1
