### PR TITLE
integration: explicitly set microk8s snap strict channel.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Running addons tests on strict
         run: |
           set -x
-          sudo snap install microk8s --channel=latest/edge/strict
+          sudo snap install microk8s --channel=1.31-strict/edge
           sudo microk8s status --wait-ready --timeout 600
           if sudo microk8s addons repo list | grep community
           then


### PR DESCRIPTION
The `latest` track of the published latest versions of the `microk8s` snap no longer has a `strict` branch defined, instead switching to using the main `$K8S_VERSION-strict/$RISK` channel naming scheme.

This patch updates the integration tests to explicitly use the `1.31-strict/edge` track/risk.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
