### PR TITLE
fix: Catches KeyError while enabling SRIOV addon

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-setuptools nfs-common
-          sudo pip3 install --upgrade pip
+          sudo pip3 install --ignore-installed --upgrade pip
           sudo pip3 install -r tests/requirements.txt
       - name: Running addons tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDEs
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# IDEs
-.idea/

--- a/addons/sriov-device-plugin/enable
+++ b/addons/sriov-device-plugin/enable
@@ -142,15 +142,18 @@ def _enable_sriovdp(resources: dict) -> None:
     while time.time() - now <= timeout:
         sriov_allocatable_resources = _get_sriov_allocatable_resources()
 
-        if all(
-            sriov_allocatable_resources.get(f"intel.com/{resource}") == str(len(pci_addresses))
-            for resource, pci_addresses in resources.items()
-        ):
-            return
+        for resource, pci_addresses in resources.items():
+            if sriov_allocatable_resources.get(f"intel.com/{resource}") != str(len(pci_addresses)):
+                print(
+                    "SR-IOV Network Device Plugin not ready: "
+                    f"intel.com/{resource} does not have enough allocatable resources."
+                )
+                break
         else:
-            print("Waiting for SR-IOV Network Device Plugin to be ready...")
+            return
 
         wait = 5
+        print(f"Waiting {wait}s for SR-IOV Network Device Plugin to be ready...")
         time.sleep(wait)
 
     raise TimeoutError("Unable to start SR-IOV Network Device Plugin. Operation timed out!")

--- a/addons/sriov-device-plugin/enable
+++ b/addons/sriov-device-plugin/enable
@@ -142,16 +142,12 @@ def _enable_sriovdp(resources: dict) -> None:
     while time.time() - now <= timeout:
         sriov_allocatable_resources = _get_sriov_allocatable_resources()
 
-        try:
-            if all(
-                sriov_allocatable_resources[f"intel.com/{resource}"] == str(len(pci_addresses))
-                for resource, pci_addresses in resources.items()
-            ):
-                return
-            else:
-                print("SR-IOV Network Device Plugin not ready, " +
-                    f"intel.com/{resource} does not have enough allocatable resources.")
-        except KeyError:
+        if all(
+            sriov_allocatable_resources.get(f"intel.com/{resource}") == str(len(pci_addresses))
+            for resource, pci_addresses in resources.items()
+        ):
+            return
+        else:
             print("Waiting for SR-IOV Network Device Plugin to be ready...")
 
         wait = 5

--- a/addons/sriov-device-plugin/enable
+++ b/addons/sriov-device-plugin/enable
@@ -142,13 +142,17 @@ def _enable_sriovdp(resources: dict) -> None:
     while time.time() - now <= timeout:
         sriov_allocatable_resources = _get_sriov_allocatable_resources()
 
-        for resource, pci_addresses in resources.items():
-            if sriov_allocatable_resources[f"intel.com/{resource}"] != str(len(pci_addresses)):
+        try:
+            if all(
+                sriov_allocatable_resources[f"intel.com/{resource}"] == str(len(pci_addresses))
+                for resource, pci_addresses in resources.items()
+            ):
+                return
+            else:
                 print("SR-IOV Network Device Plugin not ready, " +
                     f"intel.com/{resource} does not have enough allocatable resources.")
-                break
-        else:
-            return
+        except KeyError:
+            print("Waiting for SR-IOV Network Device Plugin to be ready...")
 
         wait = 5
         print(f"Waiting {wait}s for SR-IOV Network Device Plugin to be ready...")

--- a/addons/sriov-device-plugin/enable
+++ b/addons/sriov-device-plugin/enable
@@ -155,7 +155,6 @@ def _enable_sriovdp(resources: dict) -> None:
             print("Waiting for SR-IOV Network Device Plugin to be ready...")
 
         wait = 5
-        print(f"Waiting {wait}s for SR-IOV Network Device Plugin to be ready...")
         time.sleep(wait)
 
     raise TimeoutError("Unable to start SR-IOV Network Device Plugin. Operation timed out!")


### PR DESCRIPTION
This PR fixes an issue with the first iteration of the SRIOV resources availability check. 
Original implementation raises `KeyError` if the the resources are not available. As a result `while` is exiting immediately and has no effect.
This simple fix catches the `KeyError` and allows the loop to continue as expected.

Additionally, the PR fixes the `Run tests` workflow.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
