### PR TITLE
Update kata to kata-containers 3.29.0

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -124,11 +124,14 @@ microk8s-addons:
 
     - name: "kata"
       description: "Kata Containers is a secure runtime with lightweight VMS"
-      version: "latest/stable"
-      check_status: "${SNAP_DATA}/var/lock/kata.enabled"
+      version: "3.15.0"
+      check_status: "daemonset.apps/kata-deploy"
       confinement: "classic"
       supported_architectures:
+        - arm64
         - amd64
+        - s390x
+        - ppc64le
 
     - name: "inaccel"
       description: "Simplifying FPGA management in Kubernetes"

--- a/addons.yaml
+++ b/addons.yaml
@@ -124,14 +124,11 @@ microk8s-addons:
 
     - name: "kata"
       description: "Kata Containers is a secure runtime with lightweight VMS"
-      version: "3.15.0"
+      version: "3.29.0"
       check_status: "daemonset.apps/kata-deploy"
       confinement: "classic"
       supported_architectures:
-        - arm64
         - amd64
-        - s390x
-        - ppc64le
 
     - name: "inaccel"
       description: "Simplifying FPGA management in Kubernetes"

--- a/addons/kata/disable
+++ b/addons/kata/disable
@@ -1,79 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 
-import click
-import os
-import subprocess
-import sys
-from tempfile import mkstemp
-from shutil import move, copymode
-from os import fdopen, remove
+set -e
 
+HELM="${SNAP}/microk8s-helm.wrapper"
+NAMESPACE="kata-containers"
 
-def mark_kata_disabled():
-    """
-    Mark the kata addon as enabled by removing the kata.enabled lock
-    """
-    try:
-        snapdata_path = os.environ.get("SNAP_DATA")
-        lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
-        subprocess.call(['sudo', 'rm', lock_fname])
-    except (subprocess.CalledProcessError):
-        print("Failed to mark the kata addon as disabled." )
-        sys.exit(4)
+echo "Disabling kata addon"
 
-def delete_runtime_manifest():
-    try:
-        snap_path = os.environ.get("SNAP")
-        current_path = os.path.dirname(os.path.realpath(__file__))
-        manifest = "{}/kata/runtime.yaml".format(current_path)
-        subprocess.call(["{}/microk8s-kubectl.wrapper".format(snap_path), "delete", "-f", manifest])
-    except (subprocess.CalledProcessError):
-        print("Failed to apply the runtime manifest." )
-        sys.exit(5)
+"${HELM}" uninstall kata-deploy -n "${NAMESPACE}" "$@"
 
-
-def restart_containerd():
-    try:
-        print("Restarting containerd")
-        subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
-    except (subprocess.CalledProcessError):
-        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually." )
-        sys.exit(3)
-
-
-def configure_containerd():
-    """
-    Configure the containerd PATH by removing the kata runtime binary
-    """
-    snapdata_path = os.environ.get("SNAP_DATA")
-    containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
-    #Create temp file
-    fh, abs_path = mkstemp()
-    with fdopen(fh,'w') as tmp_file:
-        with open(containerd_env_file) as conf_file:
-            for line in conf_file:
-                if "KATA_PATH=" in line:
-                  line = "KATA_PATH=\n"
-                tmp_file.write(line)
-
-    copymode(containerd_env_file, abs_path)
-    remove(containerd_env_file)
-    move(abs_path, containerd_env_file)
-
-
-@click.command()
-def kata():
-    """
-    Disable the kata runtime. Mark it as disabled, delete the runtimeClassName but do not remove the
-    kata runtime because we do not know if it is used by any other application.
-    """
-    print("Configuring containerd")
-    configure_containerd()
-    restart_containerd()
-    print("Deleting kata runtime manifest")
-    delete_runtime_manifest()
-    mark_kata_disabled()
-
-
-if __name__ == "__main__":
-    kata(prog_name="microk8s disable kata")
+echo "Disabled kata addon"

--- a/addons/kata/disable
+++ b/addons/kata/disable
@@ -3,10 +3,10 @@
 set -e
 
 HELM="${SNAP}/microk8s-helm.wrapper"
-NAMESPACE="kata-containers"
+KATA_NAMESPACE="kata-containers"
 
 echo "Disabling kata addon"
 
-"${HELM}" uninstall kata-deploy -n "${NAMESPACE}" "$@"
+"${HELM}" uninstall kata-deploy -n "${KATA_NAMESPACE}"
 
 echo "Disabled kata addon"

--- a/addons/kata/disable
+++ b/addons/kata/disable
@@ -2,7 +2,7 @@
 
 set -e
 
-HELM="${SNAP}/microk8s-helm.wrapper"
+HELM="${SNAP}/microk8s-helm3.wrapper"
 KATA_NAMESPACE="kata-containers"
 
 echo "Disabling kata addon"

--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -4,94 +4,84 @@ set -e
 
 . "${SNAP}/actions/common/utils.sh"
 
-debug="false"
-shims="clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"
-defaultShim="qemu"
-createRuntimeClasses="true"
-createDefaultRuntimeClass="true"
-k8sDistribution="microk8s"
-VERSION="3.15.0"
-NAMESPACE="kata-containers"
-KATA_DEPLOY_URL=https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-deploy-${VERSION}.tgz
-HELM_OPTS=
+KATA_VERSION="3.15.0"
+KATA_NAMESPACE="kata-containers"
+VALUES=
 
-# Enable dependencies
-MICROK8S_ENABLE="${SNAP}/microk8s-enable.wrapper"
-"${MICROK8S_ENABLE}" helm3
+function do_prerequisites {
+  "$SNAP/microk8s-enable.wrapper" helm3
+}
 
 function usage {
   echo "Usage: microk8s enable kata [OPTIONS]"
   echo ""
   echo "Enable the kata addon."
   echo ""
+  echo "OPTIONS:"
   echo "   -h                   Print this help message"
-  echo "   -n NAMESPACE         Use specified namespace (default: ${NAMESPACE})"
-  echo "   -v VERSION           Kata-deploy version (default: ${VERSION})"
-  echo "   --shims SHIMLIST     List of shims to install (default: \"${shims}\")"
-  echo "   --defaultShim SHIM   Default shim to use with the kata RuntimeClass (default: ${defaultShim})"
+  echo "   -v VERSION           Specify kata-deploy version (default: ${VERSION})"
+  echo "   -f values.yaml       Use values.yaml file instead of addon default values"
+  echo "    See https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml for more information about the values"
 }
 
-while [ $# -ge 1 ]; do
-  case $1 in
-    -h|-?|--help)
-      usage
-      exit 0
-      ;;
-    -n|--namespace)
-      shift
-      NAMESPACE="${1}"
-      shift
-      ;;
-    -v)
-      shift
-      VERSION="${1}"
-      shift
-      ;;
-    --shims)
-      shift
-      shims="${1}"
-      shift
-      ;;
-    --defaultShim)
-      shift
-      defaultShim="${1}"
-      shift
-      ;;
-    *)      
-      HELM_OPTS+=" ${1}"
-      shift
-      ;;
-  esac
-done
+function parse_params {
+  while getopts ":f:v:h" flag; do
+    case "${flag}" in
+            v) KATA_VERSION=${OPTARG}
+              ;;
+            f) VALUES=${OPTARG}
+              ;;
+            *) usage
+              exit 0
+              ;;
+    esac
+  done
+}
 
-HELM="$SNAP/microk8s-helm3.wrapper"
+function install_kata {
+  HELM="$SNAP/microk8s-helm3.wrapper"
+  KATA_DEPLOY_URL=https://github.com/kata-containers/kata-containers/releases/download/${KATA_VERSION}/kata-deploy-${KATA_VERSION}.tgz
 
-echo "Installing kata-containers"
+  echo "Installing kata-containers"
 
-$HELM upgrade --install kata-deploy "${KATA_DEPLOY_URL}" \
-  --create-namespace --namespace "${NAMESPACE}" \
-  --set "k8sDistribution=${k8sDistribution}" \
-  --set "env.debug=${debug}" \
-  --set "env.shims=${shims}" \
-  --set "env.defaultShim=${defaultShim}" \
-  --set "env.createRuntimeClasses=${createRuntimeClasses}" \
-  --set "env.createDefaultRuntimeClass=${createDefaultRuntimeClass}" \
-  --wait \
-  ${HELM_OPTS}
+  if [ -z "$VALUES" ]
+  then
+    $HELM upgrade --install kata-deploy "${KATA_DEPLOY_URL}" \
+      --create-namespace --namespace "${KATA_NAMESPACE}" \
+      --set "k8sDistribution=microk8s" \
+      --set "env.debug=false" \
+      --set "env.shims=clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx" \
+      --set "env.defaultShim=qemu" \
+      --set "env.createRuntimeClasses=true" \
+      --set "env.createDefaultRuntimeClass=true" \
+      --wait
+  else
+    echo "Using values file: ${VALUES}"
+    $HELM upgrade --install kata-deploy "${KATA_DEPLOY_URL}" \
+      --create-namespace --namespace "${KATA_NAMESPACE}" \
+      --set "k8sDistribution=microk8s" \
+      -f "${VALUES}" \
+      --wait
+  fi
 
-echo "================================"
-echo "Enabled kata addon."
-echo ""
-echo ""
-echo "To use the kata runtime set the 'kata' runtimeClassName, eg:"
-echo ""
-echo "apiVersion: v1"
-echo "kind: Pod"
-echo "metadata:"
-echo "  name: nginx-kata"
-echo "spec:"
-echo "  runtimeClassName: kata"
-echo "  containers:"
-echo "  - name: nginx"
-echo "    image: nginx"
-echo ""
+  echo "================================"
+  echo "Enabled kata addon."
+  echo ""
+  echo ""
+  echo "To use the kata runtime set the 'kata' runtimeClassName, eg:"
+  echo ""
+  echo "apiVersion: v1"
+  echo "kind: Pod"
+  echo "metadata:"
+  echo "  name: nginx-kata"
+  echo "spec:"
+  echo "  runtimeClassName: kata"
+  echo "  containers:"
+  echo "  - name: nginx"
+  echo "    image: nginx"
+  echo ""
+}
+
+do_prerequisites
+parse_params "$@"
+install_kata

--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -1,118 +1,97 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 
-import click
-import os
-import subprocess
-import sys
-from tempfile import mkstemp
-from shutil import move, copymode
-from os import fdopen, remove
+set -e
 
+. "${SNAP}/actions/common/utils.sh"
 
-def mark_kata_enabled():
-    """
-    Mark the kata addon as enabled by creating the kata.enabled
-    """
-    try:
-        snapdata_path = os.environ.get("SNAP_DATA")
-        lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
-        subprocess.call(["sudo", "touch", lock_fname])
-    except subprocess.CalledProcessError:
-        print("Failed to mark the kata addon as enabled.")
-        sys.exit(4)
+debug="false"
+shims="clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"
+defaultShim="qemu"
+createRuntimeClasses="true"
+createDefaultRuntimeClass="true"
+k8sDistribution="microk8s"
+VERSION="3.15.0"
+NAMESPACE="kata-containers"
+KATA_DEPLOY_URL=https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-deploy-${VERSION}.tgz
+HELM_OPTS=
 
+# Enable dependencies
+MICROK8S_ENABLE="${SNAP}/microk8s-enable.wrapper"
+"${MICROK8S_ENABLE}" helm3
 
-def apply_runtime_manifest():
-    """
-    Apply the manifest containing the definition of the kata runtimeClassName
-    """
-    try:
-        snap_path = os.environ.get("SNAP")
-        current_path = os.path.dirname(os.path.realpath(__file__))
-        manifest = "{}/kata/runtime.yaml".format(current_path)
-        subprocess.call(
-            ["{}/microk8s-kubectl.wrapper".format(snap_path), "apply", "-f", manifest]
-        )
-    except subprocess.CalledProcessError:
-        print("Failed to apply the runtime manifest.")
-        sys.exit(5)
+function usage {
+  echo "Usage: microk8s enable kata [OPTIONS]"
+  echo ""
+  echo "Enable the kata addon."
+  echo ""
+  echo "   -h                   Print this help message"
+  echo "   -n NAMESPACE         Use specified namespace (default: ${NAMESPACE})"
+  echo "   -v VERSION           Kata-deploy version (default: ${VERSION})"
+  echo "   --shims SHIMLIST     List of shims to install (default: \"${shims}\")"
+  echo "   --defaultShim SHIM   Default shim to use with the kata RuntimeClass (default: ${defaultShim})"
+}
 
+while [ $# -ge 1 ]; do
+  case $1 in
+    -h|-?|--help)
+      usage
+      exit 0
+      ;;
+    -n|--namespace)
+      shift
+      NAMESPACE="${1}"
+      shift
+      ;;
+    -v)
+      shift
+      VERSION="${1}"
+      shift
+      ;;
+    --shims)
+      shift
+      shims="${1}"
+      shift
+      ;;
+    --defaultShim)
+      shift
+      defaultShim="${1}"
+      shift
+      ;;
+    *)      
+      HELM_OPTS+=" ${1}"
+      shift
+      ;;
+  esac
+done
 
-def restart_containerd():
-    """
-    Restart the containerd service
-    """
-    try:
-        print("Restarting containerd")
-        subprocess.call(
-            ["sudo", "systemctl", "restart", "snap.microk8s.daemon-containerd"]
-        )
-    except subprocess.CalledProcessError:
-        print(
-            "Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually."
-        )
-        sys.exit(3)
+HELM="$SNAP/microk8s-helm3.wrapper"
 
+echo "Installing kata-containers"
 
-def configure_containerd(kata_path):
-    """
-    Configure the containerd PATH so it finds the kata runtime binary
-    """
-    snapdata_path = os.environ.get("SNAP_DATA")
-    containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
-    # Create temp file
-    fh, abs_path = mkstemp()
-    with fdopen(fh, "w") as tmp_file:
-        with open(containerd_env_file) as conf_file:
-            for line in conf_file:
-                if "KATA_PATH=" in line:
-                    line = 'KATA_PATH="{}"\n'.format(kata_path)
-                tmp_file.write(line)
+$HELM upgrade --install kata-deploy "${KATA_DEPLOY_URL}" \
+  --create-namespace --namespace "${NAMESPACE}" \
+  --set "k8sDistribution=${k8sDistribution}" \
+  --set "env.debug=${debug}" \
+  --set "env.shims=${shims}" \
+  --set "env.defaultShim=${defaultShim}" \
+  --set "env.createRuntimeClasses=${createRuntimeClasses}" \
+  --set "env.createDefaultRuntimeClass=${createDefaultRuntimeClass}" \
+  --wait \
+  ${HELM_OPTS}
 
-    copymode(containerd_env_file, abs_path)
-    remove(containerd_env_file)
-    move(abs_path, containerd_env_file)
-
-
-def print_next_steps():
-    print()
-    print()
-    print("To use the kata runtime set the 'kata' runtimeClassName, eg:")
-    print()
-    print("apiVersion: v1")
-    print("kind: Pod")
-    print("metadata:")
-    print("  name: nginx-kata")
-    print("spec:")
-    print("  runtimeClassName: kata")
-    print("  containers:")
-    print("  - name: nginx")
-    print("    image: nginx")
-    print()
-
-
-@click.command()
-@click.option(
-    "--runtime-path",
-    default="/opt/kata/bin",
-    help="The path to the kata container runtime binaries.",
-)
-def kata(runtime_path):
-    """
-    Enable the kata runtime. Either snap install the kata binaries or use a path to already deployed
-    kata binaries. Note the kata binary must be called kata-runtime
-    """
-    if not os.path.exists("{}/kata-runtime".format(runtime_path)):
-        print("Kata runtime binaries was not found under {}.".format(runtime_path))
-        print("Use the --runtime-path argument to point to the right location.")
-        sys.exit(2)
-
-    configure_containerd(runtime_path)
-    restart_containerd()
-    apply_runtime_manifest()
-    mark_kata_enabled()
-    print_next_steps()
-
-
-if __name__ == "__main__":
-    kata(prog_name="microk8s enable kata")
+echo "================================"
+echo "Enabled kata addon."
+echo ""
+echo ""
+echo "To use the kata runtime set the 'kata' runtimeClassName, eg:"
+echo ""
+echo "apiVersion: v1"
+echo "kind: Pod"
+echo "metadata:"
+echo "  name: nginx-kata"
+echo "spec:"
+echo "  runtimeClassName: kata"
+echo "  containers:"
+echo "  - name: nginx"
+echo "    image: nginx"
+echo ""

--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -49,11 +49,10 @@ function install_kata {
     $HELM upgrade --install kata-deploy "${KATA_DEPLOY_URL}" \
       --create-namespace --namespace "${KATA_NAMESPACE}" \
       --set "k8sDistribution=microk8s" \
-      --set "env.debug=false" \
-      --set "env.shims=clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx" \
-      --set "env.defaultShim=qemu" \
       --set "env.createRuntimeClasses=true" \
       --set "env.createDefaultRuntimeClass=true" \
+      --set "runtimeClasses.enabled=true" \
+      --set "runtimeClasses.createDefault=true" \
       --wait
   else
     echo "Using values file: ${VALUES}"

--- a/addons/kata/enable
+++ b/addons/kata/enable
@@ -4,7 +4,7 @@ set -e
 
 . "${SNAP}/actions/common/utils.sh"
 
-KATA_VERSION="3.15.0"
+KATA_VERSION="3.29.0"
 KATA_NAMESPACE="kata-containers"
 VALUES=
 
@@ -19,7 +19,7 @@ function usage {
   echo ""
   echo "OPTIONS:"
   echo "   -h                   Print this help message"
-  echo "   -v VERSION           Specify kata-deploy version (default: ${VERSION})"
+  echo "   -v VERSION           Specify kata-deploy version (default: ${KATA_VERSION})"
   echo "   -f values.yaml       Use values.yaml file instead of addon default values"
   echo "    See https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml for more information about the values"
 }

--- a/addons/kata/kata/runtime.yaml
+++ b/addons/kata/kata/runtime.yaml
@@ -1,5 +1,0 @@
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: kata
-handler: kata

--- a/tests/test_kata.py
+++ b/tests/test_kata.py
@@ -18,10 +18,6 @@ class TestKata(object):
         reason="Skipping kata tests in strict confinement as they are expected to fail",
     )
     @pytest.mark.skipif(
-        platform.machine() != "x86_64",
-        reason="Kata tests are only relevant in x86 architectures",
-    )
-    @pytest.mark.skipif(
         is_container(), reason="Kata tests are only possible on real hardware"
     )
     def test_kata(self):


### PR DESCRIPTION
###  Update kata to kata-containers 3.15.0

This PR updates the kata addon #256, replacing usage of snap kata-container with deployment of kata-deploy helm release which support microk8s since kata-containers 3.15.0

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
