### PR TITLE
test: fix dashboard tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,8 +25,16 @@ jobs:
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
 
+          if sudo microk8s addons repo list | grep community
+          then
+            sudo microk8s addons repo remove community
+          fi
+          if sudo microk8s addons repo list | grep core
+          then
+            sudo microk8s addons repo remove core
+          fi
           sudo microk8s addons repo add community .
-          sudo microk8s addons repo update core
+          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
 
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
@@ -51,8 +59,16 @@ jobs:
           sudo snap install microk8s --channel=latest/edge/strict
           sudo microk8s status --wait-ready --timeout 600
 
+          if sudo microk8s addons repo list | grep community
+          then
+            sudo microk8s addons repo remove community
+          fi
+          if sudo microk8s addons repo list | grep core
+          then
+            sudo microk8s addons repo remove core
+          fi
           sudo microk8s addons repo add community .
-          sudo microk8s addons repo update core
+          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
 
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,16 +25,8 @@ jobs:
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
 
-          if sudo microk8s addons repo list | grep community
-          then
-            sudo microk8s addons repo remove community
-          fi
-          if sudo microk8s addons repo list | grep core
-          then
-            sudo microk8s addons repo remove core
-          fi
           sudo microk8s addons repo add community .
-          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
+          sudo microk8s addons repo update core
 
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
@@ -59,16 +51,8 @@ jobs:
           sudo snap install microk8s --channel=latest/edge/strict
           sudo microk8s status --wait-ready --timeout 600
 
-          if sudo microk8s addons repo list | grep community
-          then
-            sudo microk8s addons repo remove community
-          fi
-          if sudo microk8s addons repo list | grep core
-          then
-            sudo microk8s addons repo remove core
-          fi
           sudo microk8s addons repo add community .
-          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
+          sudo microk8s addons repo update core
 
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,14 +7,12 @@ on:
     branches: [main]
 
 jobs:
-  run-tests:
-    name: Run tests
+  run-tests-classic:
+    name: Run tests (classic)
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -42,6 +40,19 @@ jobs:
           export SKIP_PROMETHEUS="False"
           sudo -E pytest -s -ra ./tests/
           sudo snap remove microk8s --purge
+
+  run-tests-strict:
+    name: Run tests (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-setuptools nfs-common
+          sudo pip3 install --ignore-installed --upgrade pip
+          sudo pip3 install -r tests/requirements.txt
       - name: Running addons tests on strict
         run: |
           set -x

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,11 +26,18 @@ jobs:
           set -x
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
+
           if sudo microk8s addons repo list | grep community
           then
             sudo microk8s addons repo remove community
           fi
+          if sudo microk8s addons repo list | grep core
+          then
+            sudo microk8s addons repo remove core
+          fi
           sudo microk8s addons repo add community .
+          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
+
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
           sudo -E pytest -s -ra ./tests/
@@ -40,11 +47,18 @@ jobs:
           set -x
           sudo snap install microk8s --channel=latest/edge/strict
           sudo microk8s status --wait-ready --timeout 600
+
           if sudo microk8s addons repo list | grep community
           then
             sudo microk8s addons repo remove community
           fi
+          if sudo microk8s addons repo list | grep core
+          then
+            sudo microk8s addons repo remove core
+          fi
           sudo microk8s addons repo add community .
+          sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons
+
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
           export STRICT="yes"

--- a/addons/dashboard-ingress/enable
+++ b/addons/dashboard-ingress/enable
@@ -115,7 +115,7 @@ def dashboard_ingress(hostname, allow, auth, auth_user, password):
         "kind": "Ingress",
         "metadata": {
             "name": "kubernetes-dashboard-ingress",
-            "namespace": "kube-system",
+            "namespace": "kubernetes-dashboard",
             "annotations": {
                 "kubernetes.io/ingress.class": "public",
 
@@ -136,7 +136,7 @@ def dashboard_ingress(hostname, allow, auth, auth_user, password):
                         "pathType": "Prefix",
                         "backend": {
                             "service": {
-                                "name": "kubernetes-dashboard",
+                                "name": "kubernetes-dashboard-kong-proxy",
                                 "port": {"number": 443}
                             }
                         }
@@ -157,7 +157,7 @@ def dashboard_ingress(hostname, allow, auth, auth_user, password):
                 "kind": "Secret",
                 "metadata": {
                     "name": "kubernetes-dashboard-basic-auth",
-                    "namespace": "kube-system"
+                    "namespace": "kubernetes-dashboard"
                 },
                 "data": {"auth": encoded_auth},
                 "type": "Opaque"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -93,19 +93,24 @@ class TestCommon(object):
         Validate the dashboard addon by trying to access the kubernetes dashboard.
         The dashboard will return an HTML indicating that it is up and running.
         """
-        wait_for_pod_state(
-            "", "kube-system", "running", label="k8s-app=kubernetes-dashboard"
-        )
-        wait_for_pod_state(
-            "", "kube-system", "running", label="k8s-app=dashboard-metrics-scraper"
-        )
+        ns = "kubernetes-dashboard"
+        components = ["api", "auth", "metrics-scraper", "web"]
+        app_names = [f"kubernetes-dashboard-{app}" for app in components]
+        app_names.append("kong")
+
+        for app_name in app_names:
+            wait_for_pod_state(
+                "", ns, "running", label=f"app.kubernetes.io/name={app_name}"
+            )
+
+        service = "kubernetes-dashboard-kong-proxy"
         attempt = 30
         while attempt > 0:
             try:
                 output = kubectl(
                     "get "
                     "--raw "
-                    "/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/"
+                    f"/api/v1/namespaces/{ns}/services/https:{service}:443/proxy/"
                 )
                 if "Kubernetes Dashboard" in output:
                     break

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -90,7 +90,7 @@ def kubectl_get(target, timeout_insec=300):
 
 
 def wait_for_pod_state(
-    pod, namespace, desired_state, desired_reason=None, label=None, timeout_insec=1200
+    pod, namespace, desired_state, desired_reason=None, label=None, timeout_insec=600
 ):
     """
     Wait for a a pod state. If you do not specify a pod name and you set instead a label
@@ -127,7 +127,7 @@ def wait_for_pod_state(
         time.sleep(3)
 
 
-def wait_for_installation(cluster_nodes=1, timeout_insec=600):
+def wait_for_installation(cluster_nodes=1, timeout_insec=360):
     """
     Wait for kubernetes service to appear.
     """
@@ -152,7 +152,7 @@ def wait_for_installation(cluster_nodes=1, timeout_insec=600):
     time.sleep(30)
 
 
-def wait_for_namespace_termination(namespace, timeout_insec=600):
+def wait_for_namespace_termination(namespace, timeout_insec=360):
     """
     Wait for the termination of the provided namespace.
     """


### PR DESCRIPTION
The dashboard core addon has been updated, so we need to update the dashboard tests as well as the dashboard-ingress addon:

https://github.com/canonical/microk8s-core-addons/commit/77e062c0387b6763c18f9e8b0c863a5149346fec

The tests currently fail since they're expecting the old dashboard pods (different ns, labels).

While at it, we're restoring the timeout values since that wasn't the problem. Also, we're updating the test job to use latest version of the core addons.