### PR TITLE
Install ArgoCD cli

### DIFF
--- a/addons/argocd/argocd
+++ b/addons/argocd/argocd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+KUBECONFIG="$SNAP_DATA/credentials/client.config" ${SNAP_DATA}/bin/argocd $*

--- a/addons/argocd/disable
+++ b/addons/argocd/disable
@@ -31,10 +31,10 @@ echo "Disabling ArgoCD"
 
 $HELM delete argo-cd -n $NAMESPACE_ARGOCD
 
-$KUBECTL delete customresourcedefinition applications.argoproj.io \
-                applicationsets.argoproj.io \
-                argocdextensions.argoproj.io  \
-                appprojects.argoproj.io
+$KUBECTL delete customresourcedefinition applications.argoproj.io || true
+$KUBECTL delete customresourcedefinition applicationsets.argoproj.io || true
+$KUBECTL delete customresourcedefinition argocdextensions.argoproj.io || true
+$KUBECTL delete customresourcedefinition appprojects.argoproj.io || true
 
 if $PURGE; then
     echo "Final \"$NAMESPACE_ARGOCD\" namespace deletion"
@@ -45,6 +45,14 @@ else
     echo ""
     echo "Purge only when sure, that \"$NAMESPACE_ARGOCD\" namespace is not hosting any other services from Argo stack."
     echo ""
+fi
+
+if [ -f "$SNAP_COMMON/plugins/argocd" ]; then
+  run_with_sudo rm -f "$SNAP_COMMON/plugins/argocd"
+fi
+
+if [ -f "$SNAP_DATA/bin/argocd" ]; then
+  run_with_sudo rm -f "$SNAP_DATA/bin/argocd"
 fi
 
 echo "ArgoCD disabled"

--- a/addons/argocd/enable
+++ b/addons/argocd/enable
@@ -7,6 +7,7 @@ source $SNAP/actions/common/utils.sh
 NAMESPACE_ARGOCD="argocd"
 
 ARGOCD_HELM_VERSION="5.34.3"
+ARGOCD_VERSION="2.7.2"
 
 "$SNAP/microk8s-enable.wrapper" helm3
 
@@ -16,14 +17,18 @@ HELM="$SNAP/microk8s-helm3.wrapper"
 VALUES=""
 
 # get the options
-while getopts ":v:f:h:" flag; do
+while getopts ":v:c:f:h:" flag; do
   case "${flag}" in
           v) ARGOCD_HELM_VERSION=${OPTARG}
+             ;;
+          c) ARGOCD_VERSION=${OPTARG}
              ;;
           f) VALUES=${OPTARG}
              ;;
           *) echo "Usage: microk8s enable argocd"
              echo ""
+             echo "With custom ArgoCD CLI version: microk8s enable argocd -v 5.34.3"
+             echo "With custom ArgoCD CLI version: microk8s enable argocd -c 2.7.2"
              echo "With overwriting default values: microk8s enable argocd -f values.yaml"
              echo ""
              echo "See https://artifacthub.io/packages/helm/argo/argo-cd for more information about the values"
@@ -33,6 +38,39 @@ while getopts ":v:f:h:" flag; do
              ;;
   esac
 done
+
+# Function to detect and map system architecture
+detect_architecture() {
+  local arch=$(uname -m)
+  case $arch in
+    x86_64)
+      echo "amd64"
+      ;;
+    aarch64|arm64)
+      echo "arm64"
+      ;;
+    *)
+      echo "Unsupported architecture: $arch" >&2
+      echo "Supported architectures: x86_64 (amd64), aarch64/arm64" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Install the argocd CLI if it is not already installed
+if [ ! -f "${SNAP_DATA}/bin/argocd" ]
+then
+  echo "Fetching argocd CLI version v$ARGOCD_VERSION."
+
+  ARCH=$(detect_architecture)
+  SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+  fetch_as https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${ARCH} "$SNAP_DATA/bin/argocd"
+  run_with_sudo chmod +x "$SNAP_DATA/bin/argocd"
+
+  run_with_sudo cp "${SCRIPT_DIR}/argocd" "${SNAP_COMMON}/plugins/argocd"
+  run_with_sudo chmod +x "${SNAP_COMMON}/plugins/argocd"
+fi
 
 echo "Installing ArgoCD (Helm v${ARGOCD_HELM_VERSION})"
 

--- a/tests/test_argocd.py
+++ b/tests/test_argocd.py
@@ -5,6 +5,7 @@ import platform
 from utils import (
     microk8s_disable,
     microk8s_enable,
+    run_until_success,
     wait_for_pod_state,
 )
 
@@ -29,6 +30,63 @@ class TestArgoCD(object):
         print("Disabling argocd")
         microk8s_disable("argocd")
 
+    @pytest.mark.skipif(
+        platform.machine() == "s390x",
+        reason="ArgoCD tests are only relevant in x86 and arm64 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping argocd tests as we are under time pressure",
+    )
+    def test_argocd_with_custom_helm_version(self):
+        """
+        Sets up and validates ArgoCD with custom Helm chart version.
+        """
+        print("Enabling argocd with custom Helm version")
+        microk8s_enable("argocd", args=["-v", "5.35.0"])
+        print("Validating argocd")
+        self.validate_argocd()
+        print("Disabling argocd")
+        microk8s_disable("argocd")
+
+    @pytest.mark.skipif(
+        platform.machine() == "s390x",
+        reason="ArgoCD tests are only relevant in x86 and arm64 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping argocd tests as we are under time pressure",
+    )
+    def test_argocd_with_custom_cli_version(self):
+        """
+        Sets up and validates ArgoCD with custom CLI version.
+        """
+        print("Enabling argocd with custom CLI version")
+        microk8s_enable("argocd", args=["-c", "2.8.0"])
+        print("Validating argocd")
+        self.validate_argocd()
+        print("Disabling argocd")
+        microk8s_disable("argocd")
+
+    @pytest.mark.skipif(
+        platform.machine() == "s390x",
+        reason="ArgoCD tests are only relevant in x86 and arm64 architectures",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping argocd tests as we are under time pressure",
+    )
+    def test_argocd_with_custom_helm_and_cli_versions(self):
+        """
+        Sets up and validates ArgoCD with both custom Helm and CLI versions.
+        """
+        print("Enabling argocd with custom Helm and CLI versions")
+        microk8s_enable("argocd", args=["-v", "5.35.0", "-c", "2.8.0"])
+        print("Validating argocd")
+        self.validate_argocd()
+        print("Disabling argocd")
+        microk8s_disable("argocd")
+
     def validate_argocd(self):
         """
         Validate argocd
@@ -36,3 +94,7 @@ class TestArgoCD(object):
         wait_for_pod_state(
             "", "argocd", "running", label="app.kubernetes.io/component=server"
         )
+
+        cmd = "/snap/bin/microk8s.argocd version --client"
+        output = run_until_success(cmd, timeout_insec=30)
+        assert "argocd: v" in output, "ArgoCD CLI version output should contain 'argocd: v'"


### PR DESCRIPTION
## ArgoCD cli installation

### Description
Implements the issue https://github.com/canonical/microk8s-community-addons/issues/148, installing the ArgoCD cli when enabling the ArgoCD addon.

### Solution
- Update the enable script to check if the cli is not installed if so the cli is being installed based on the arch
- Update the disable script to remove the cli and also fix a problem if any of the K8S resources being deleted are not found
- Create of a custom command for using with "microk8s argocd"
- Update unit tests to cover some parts that were missing and also the cli

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
