### PR TITLE
update ngrok addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -236,9 +236,9 @@ microk8s-addons:
         - amd64
 
     - name: "ngrok"
-      description: "ngrok Ingress Controller instantly adds connectivity, load balancing, authentication, and observability to your services"
-      version: "0.0.1"
-      check_status: "deployment.apps/ngrok-ingress-controller-kubernetes-ingress-controller-manager"
+      description: "ngrok's Kubernetes-native operator — bring API gateway power to your cluster with automated connectivity, auth, and observability"
+      version: "0.19.0"
+      check_status: "deployment.apps/ngrok-operator-manager"
       confinement: "classic"
       supported_architectures:
         - arm64

--- a/addons/ngrok/disable
+++ b/addons/ngrok/disable
@@ -26,12 +26,12 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 if [ -z "$NAMESPACE" ]; then
-  echo "Namespace (--namespace) was not specified. Defaulting to ngrok-ingress-controller namespace."
-  NAMESPACE="ngrok-ingress-controller"
+  echo "Namespace (--namespace) was not specified. Defaulting to ngrok-operator namespace."
+  NAMESPACE="ngrok-operator"
 fi
 
-echo "Disabling ngrok Ingress controller in ${NAMESPACE} namespace"
+echo "Disabling ngrok Kubernetes operator in ${NAMESPACE} namespace"
 
-"${HELM}" uninstall ngrok-ingress-controller --namespace "${NAMESPACE}"
+"${HELM}" uninstall ngrok-operator --namespace "${NAMESPACE}"
 
-echo "Disabled ngrok Ingress controller"
+echo "Disabled ngrok Kubernetes operator"

--- a/addons/ngrok/enable
+++ b/addons/ngrok/enable
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 HELM="${SNAP}/microk8s-helm.wrapper"
-VERSION=0.12.1
+VERSION=0.19.0
 
 POSITIONAL_ARGS=()
 
@@ -41,35 +41,38 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 if [ -z "$NAMESPACE" ]; then
-  echo "Namespace (--namespace) was not specified. Defaulting to ngrok-ingress-controller namespace."
-  NAMESPACE="ngrok-ingress-controller"
+  echo "Namespace (--namespace) was not specified. Defaulting to ngrok-operator namespace."
+  NAMESPACE="ngrok-operator"
 fi
 
 if [ -z "$SECRET_NAME" ]; then
   if [ -z "$NGROK_AUTHTOKEN" ] || [ -z "$NGROK_API_KEY" ]; then
-    echo "Either --secret-name or both --authtoken and --api-key must be specified. Please see https://github.com/ngrok/kubernetes-ingress-controller#installation for more information."
+    echo "Either --secret-name or both --authtoken and --api-key must be specified. Please see https://ngrok.com/docs/getting-started/kubernetes/ingress/ for more information."
     exit 1
   fi
 fi
 
-echo "Enabling ngrok ingress controller in {$NAMESPACE} namespace"
+echo "Enabling ngrok Kubernetes operator in ${NAMESPACE} namespace"
 
-"${HELM}" repo update ngrok || "${HELM}" repo add ngrok https://ngrok.github.io/kubernetes-ingress-controller
+"${HELM}" repo update ngrok || "${HELM}" repo add ngrok https://charts.ngrok.com
 
 if [ -n "$SECRET_NAME" ]; then
-  "${HELM}" upgrade --install --create-namespace ngrok-ingress-controller ngrok/kubernetes-ingress-controller --namespace "${NAMESPACE}" --set credentials.secret.name="${SECRET_NAME}" --version=${VERSION}
+  "${HELM}" upgrade --install --create-namespace ngrok-operator ngrok/ngrok-operator --namespace "${NAMESPACE}" --set credentials.secret.name="${SECRET_NAME}" --version=${VERSION}
 else
-  "${HELM}" upgrade --install --create-namespace ngrok-ingress-controller ngrok/kubernetes-ingress-controller --namespace "${NAMESPACE}" --set credentials.apiKey="${NGROK_API_KEY}" --set credentials.authtoken="${NGROK_AUTHTOKEN}" --version=${VERSION}
+  "${HELM}" upgrade --install --create-namespace ngrok-operator ngrok/ngrok-operator --namespace "${NAMESPACE}" --set credentials.apiKey="${NGROK_API_KEY}" --set credentials.authtoken="${NGROK_AUTHTOKEN}" --version=${VERSION}
 fi
 
 echo "---"
 echo ""
-echo "The ngrok Ingress controller has been successfully installed in the ${NAMESPACE} namespace."
+echo "The ngrok Kubernetes operator has been successfully installed in the ${NAMESPACE} namespace."
 echo ""
 
 if [ -n "$SECRET_NAME" ]; then
-    echo "You specified a secret named ${SECRET_NAME}. Please ensure that secret exists in your cluster. For help, please see https://github.com/ngrok/kubernetes-ingress-controller/blob/main/docs/deployment-guide/credentials.md#creating-the-secret"
+    echo "You specified a secret named ${SECRET_NAME}. Please ensure that secret exists in your cluster with the keys 'API_KEY' and 'AUTHTOKEN'."
+    echo "For help creating the secret, see: https://ngrok.com/docs/getting-started/kubernetes/ingress/"
     echo ""
 fi
 
-echo "Next, you can start creating Ingress resources to access your services through ngrok. Please check out https://github.com/ngrok/kubernetes-ingress-controller for examples."
+echo "Now you can create Ingress resources with 'ingressClassName: ngrok' to expose your services through ngrok."
+echo "If you have the Gateway API CRDs installed, you can use those with ngrok too. See https://ngrok.com/docs/getting-started/kubernetes/gateway-api/ for examples."
+echo "For the getting-started guide, see: https://ngrok.com/docs/getting-started/kubernetes/ingress/"

--- a/tests/test_ngrok.py
+++ b/tests/test_ngrok.py
@@ -10,7 +10,6 @@ from utils import (
 
 
 class TestNgrok(object):
-    @pytest.mark.skip(reason="Ngrok ingress controller is depreciated.")
     @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     @pytest.mark.skipif(
         os.environ.get("STRICT") == "yes",
@@ -22,23 +21,23 @@ class TestNgrok(object):
     )
     def test_ngrok(self):
         """
-        Sets up and validates ngrok.
+        Sets up and validates the ngrok kubernetes operator.
         """
-        print("Enabling ngrok")
+        print("Enabling ngrok kubernetes operator")
         microk8s_enable(
             addon="ngrok",
-            optional_args="--namespace ngrok-ingress-controller --secret-name test",
+            optional_args="--namespace ngrok-operator --secret-name test",
         )
-        print("Validating ngrok")
+        print("Validating ngrok kubernetes operator")
         self.validate_ngrok()
-        print("Disabling ngrok")
+        print("Disabling ngrok kubernetes operator")
         microk8s_disable("ngrok")
 
     def validate_ngrok(self):
         """
-        Validate ngrok
+        Validate ngrok kubernetes operator
         """
         kubectl_get(
-            "deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager"
-            " -n ngrok-ingress-controller"
+            "deployment ngrok-operator-manager"
+            " -n ngrok-operator"
         )


### PR DESCRIPTION
### Thank you for making MicroK8s better

In response to https://github.com/canonical/microk8s-community-addons/pull/267, this updates the ngrok addon to no longer use the deprecated ngrok ingress controller which is no longer in development for the new ngrok kubernetes operator which is in active development.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
