### PR TITLE
AMD GPU Hardware support addon

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -258,3 +258,11 @@ microk8s-addons:
       check_status: "daemonset.apps/kube-sriov-device-plugin"
       supported_architectures:
         - amd64
+
+    - name: "amd"
+      version: "1.0.0"
+      description: "AMD hardware support"
+      check_status: "deployment.apps/amd-gpu-operator-gpu-operator-charts-controller-manager"
+      confinement: "classic"
+      supported_architectures:
+        - amd64

--- a/addons/amd/disable
+++ b/addons/amd/disable
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+import click
+
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+HELM = SNAP / "microk8s-helm3.wrapper"
+
+@click.command()
+@click.option("--debug", is_flag=True)
+def main(debug: bool):
+    click.echo("Disabling AMD GPU operator")
+    uninstall_args = ["uninstall", "amd-gpu-operator", "-n", "kube-amd-gpu"]
+
+    if debug:
+        uninstall_args.append("--debug")
+
+    subprocess.check_output([HELM, *uninstall_args])
+
+if __name__ == "__main__":
+    main()
+    
+

--- a/addons/amd/enable
+++ b/addons/amd/enable
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+import click
+import sys
+import re
+from typing import Optional
+
+SNAP = pathlib.Path(os.getenv("SNAP") or "/snap/microk8s/current")
+HELM = SNAP / "microk8s-helm3.wrapper"
+KUBECTL = SNAP / "microk8s-kubectl.wrapper"
+MICROK8S_ENABLE = SNAP / "microk8s-enable.wrapper"
+    
+def cert_manager_install(cert_manager_version, debug): # add cert manager version flag
+    click.echo("Installing cert-manager")
+    subprocess.run([HELM, "repo", "add", "jetstack", "https://charts.jetstack.io", "--force-update"])
+    version = cert_manager_version if cert_manager_version is not None else "v1.15.1"
+    cert_install_args = [
+        "install", 
+        "cert-manager", 
+        "jetstack/cert-manager", 
+        "--namespace", 
+        "cert-manager",
+        "--create-namespace",
+        "--version",
+        version,
+        "--set",
+        "crds.enabled=true"
+    ] 
+
+    if debug:
+        cert_install_args.append("--debug")
+
+    subprocess.run([HELM, *cert_install_args])
+
+def deploy_gpu_operator(
+    helm_set : list,
+    helm_values: Optional[str],
+    version: Optional[str],
+    debug: bool,
+):
+    click.echo("Deploying AMD GPU Operator")
+
+    subprocess.run([HELM, "repo", "add", "rocm", "https://rocm.github.io/gpu-operator"])
+    subprocess.run([HELM, "repo", "update"])
+
+    operator_args = [
+        "install",
+        "amd-gpu-operator",
+        "rocm/gpu-operator-charts",
+        "--namespace",
+        "kube-amd-gpu",
+        "--create-namespace"
+    ]
+
+    if version is not None:
+        operator_args.extend(["--version", version])
+    for set in helm_set:
+        operator_args.extend(["--set", set])
+    if helm_values is not None:
+        operator_args.extend(["-f", helm_values])
+    if debug:
+        operator_args.append("--debug")
+
+    subprocess.run([HELM, *operator_args])
+    
+
+@click.command()
+@click.option("--install-cert-manager", type=bool, default=True)
+@click.option("--gpu-operator-version")
+@click.option("--cert-manager-version")
+@click.option("--gpu-operator-set", multiple=True)
+@click.option("--gpu-operator-values", type=click.Path(exists=True))
+@click.option("--debug", is_flag=True)
+def main(
+    install_cert_manager: bool,
+    gpu_operator_version: Optional[str],
+    cert_manager_version: Optional[str],
+    gpu_operator_set: Optional[list],
+    gpu_operator_values: Optional[str],
+    debug: bool,
+):
+    if gpu_operator_version is not None:
+        version_pattern = r'^v\d+\.\d+\.\d+$'
+        if not bool(re.match(version_pattern, gpu_operator_version)):
+            click.echo(f"ERROR: Invalid version string {gpu_operator_version}", err=True)
+            sys.exit(1)
+
+    subprocess.run([MICROK8S_ENABLE, "core/helm"]) # automatically enabled for newer versions of microk8s
+    if install_cert_manager:
+        cert_manager_install(cert_manager_version, debug)
+    else:
+        click.echo("Skipping cert-manager install")
+    deploy_gpu_operator(
+        helm_set=gpu_operator_set, 
+        helm_values=gpu_operator_values, 
+        version=gpu_operator_version,
+        debug=debug,
+    )
+
+if __name__ == "__main__":
+    main()
+    

--- a/tests/templates/amd-values.yaml
+++ b/tests/templates/amd-values.yaml
@@ -1,0 +1,8 @@
+deviceConfig:
+  spec:
+    selector:
+      unit-test-check: "true"
+    metricsExporter:
+      enable: false
+    testRunner:
+      enable: true

--- a/tests/test_amd.py
+++ b/tests/test_amd.py
@@ -1,0 +1,72 @@
+import pytest
+import os
+import platform
+import subprocess
+import yaml
+from pathlib import Path
+
+from utils import (
+    microk8s_enable,
+    microk8s_disable,
+    kubectl,
+)
+from subprocess import CalledProcessError
+
+TEMPLATES = Path(__file__).absolute().parent / "templates"
+
+class TestAMD(object):
+    @pytest.mark.skipif(
+        os.environ.get("STRICT") == "yes",
+        reason="Skipping AMD tests in strict confinement as they are expected to fail",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping AMD tests as we are under time pressure",
+    )
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="AMD tests are only relevant in x86 architectures",
+    )
+    def test_amd(self):
+        """
+        Sets up amd gpu operator in a gpu capable system. Skip otherwise.
+
+        """
+        here = os.path.dirname(os.path.abspath(__file__))
+        values_template = os.path.join(here, "templates", "amd-values.yaml")
+        try:
+            print("Enabling amd")
+            microk8s_enable("amd --gpu-operator-values {}".format(values_template))
+            print("Enabled")
+        except CalledProcessError:
+            print("Could not enable amd addon")
+            return
+        self.validate_amd()
+        try:
+            print("Disabling amd")
+            microk8s_disable("amd")
+            print("Disabled")
+        except CalledProcessError:
+            print("Could not disable amd addon")
+            return
+    
+    def validate_amd(self):
+        """
+        Validate AMD by checking deviceConfig.
+        """
+
+        if platform.machine() != "x86_64":
+            print("GPU tests are only relevant on x86 architectures")
+            return
+        
+        print("Checking deviceconfig")
+        namespace = "kube-amd-gpu"
+        device_config_string = kubectl(f"get deviceconfig default -n {namespace} -o yaml")
+        device_config_spec = yaml.safe_load(device_config_string)["spec"]
+
+        selector_passed = device_config_spec["selector"]["unit-test-check"] == "true"
+        test_runner_passed = device_config_spec["testRunner"]["enable"]
+        metrics_exporter_passed = not device_config_spec["metricsExporter"]["enable"]
+
+        assert selector_passed and test_runner_passed and metrics_exporter_passed
+        print("Check passed")

--- a/tests/test_amd.py
+++ b/tests/test_amd.py
@@ -14,6 +14,7 @@ from subprocess import CalledProcessError
 
 TEMPLATES = Path(__file__).absolute().parent / "templates"
 
+
 class TestAMD(object):
     @pytest.mark.skipif(
         os.environ.get("STRICT") == "yes",
@@ -49,7 +50,7 @@ class TestAMD(object):
         except CalledProcessError:
             print("Could not disable amd addon")
             return
-    
+
     def validate_amd(self):
         """
         Validate AMD by checking deviceConfig.
@@ -58,10 +59,12 @@ class TestAMD(object):
         if platform.machine() != "x86_64":
             print("GPU tests are only relevant on x86 architectures")
             return
-        
+
         print("Checking deviceconfig")
         namespace = "kube-amd-gpu"
-        device_config_string = kubectl(f"get deviceconfig default -n {namespace} -o yaml")
+        device_config_string = kubectl(
+            f"get deviceconfig default -n {namespace} -o yaml"
+        )
         device_config_spec = yaml.safe_load(device_config_string)["spec"]
 
         selector_passed = device_config_spec["selector"]["unit-test-check"] == "true"


### PR DESCRIPTION
Microk8s addon to enable AMD GPU hardware support. This addon, when enabled, installs the AMD GPU Operator (https://instinct.docs.amd.com/projects/gpu-operator/en/latest/) on the Microk8s cluster. When disabled, it uninstalls the GPU Operator.

[✓] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
[✓] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.