### PR TITLE
ci: disable ngrok ingress controller test on 1.32 (#267)

### DIFF
--- a/tests/test_ngrok.py
+++ b/tests/test_ngrok.py
@@ -10,6 +10,7 @@ from utils import (
 
 
 class TestNgrok(object):
+    @pytest.mark.skip(reason="Ngrok ingress controller is depreciated.")
     @pytest.mark.skipif(platform.machine() == "s390x", reason="Not available on s390x")
     @pytest.mark.skipif(
         os.environ.get("STRICT") == "yes",


### PR DESCRIPTION
### ci: disable ngrok ingress controller test on 1.32
Backport: (#267).
*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
