### PR TITLE
feat(falco) updating falco to the latest version of the helm chart

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -220,7 +220,7 @@ microk8s-addons:
 
     - name: "falco"
       description: "Cloud-native runtime threat detection tool for Linux and K8s"
-      version: "4.5.1"
+      version: "8.0.1"
       check_status: "daemonset.apps/falco"
       supported_architectures:
         - amd64

--- a/addons/falco/enable
+++ b/addons/falco/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_FALCO="falco"
 
-FALCO_HELM_VERSION="4.5.1"
+FALCO_HELM_VERSION="8.0.1"
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm3.wrapper"
@@ -60,7 +60,8 @@ get_falco() {
         --create-namespace \
         --version $FALCO_HELM_VERSION \
         --set driver.kind="modern_ebpf" \
-        --set collectors.containerd.socket="/var/snap/microk8s/common/run/containerd.sock" \
+        --set 'collectors.containerEngine.engines.containerd.sockets={/var/snap/microk8s/common/run/containerd.sock,/run/host-container/containerd.sock}' \
+        --set 'collectors.containerEngine.engines.cri.sockets={/var/snap/microk8s/common/run/containerd.sock,/run/containerd/containerd.sock,/run/crio/crio.sock,/run/k3s/containerd/containerd.sock,/run/host-containerd/containerd.sock}' \
         --set falcosidekick.enabled=true \
         --set falcosidekick.replicaCount=1 \
         --set falcosidekick.webui.enabled=true \

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ import yaml
 import platform
 from subprocess import check_output, CalledProcessError, check_call
 
-
 arch_translate = {"aarch64": "arm64", "x86_64": "amd64"}
 
 


### PR DESCRIPTION
Upgrading falco extension to the latest version (8.0.1) of the helm chart
Updated the default configuration to use the new helm values and point at the microk8s installation

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
