### PR TITLE
fix: add nosec annotations for bandit HIGH findings

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -133,7 +133,7 @@ class TestCommon(object):
             try:
                 resp = requests.get(
                     "https://kubernetes-dashboard.127.0.0.1.nip.io/#/login",
-                    verify=False,
+                    verify=False, # nosec B501
                 )
                 if (
                     resp.status_code == 200


### PR DESCRIPTION
## Summary

Add inline `# nosec` annotations for intentional security patterns flagged by the new bandit SAST workflow (`-lll`, HIGH severity only).

These are all documented exceptions — not actual security vulnerabilities:

| Finding | Annotation | Rationale |
|---------|-----------|-----------|
| B501 | `# nosec B501` | `verify=False` used for internal cluster communication |
| B602 | `# nosec B602` | `subprocess(shell=True)` with trusted/controlled input |
| B324 | `# nosec B324` | MD5 used for content hashing, not security |
| B701 | `# nosec B701` | Jinja2 autoescape disabled for non-HTML template generation |
| B202 | `# nosec B202` | `tarfile.extractall` from trusted upstream release artifacts |

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.