### PR TITLE
chore: branch out 1.35

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,8 +1,8 @@
 name: Lint Code
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches: [1.35]
 
 jobs:
   check-formatting:

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,5 +1,8 @@
 name: cla-check
-on: [pull_request]
+
+on:
+  pull_request:
+    branches: [1.35]
 
 jobs:
   cla-check:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,8 @@
 name: Run tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches: [1.35]
 
 jobs:
   run-tests-classic:
@@ -22,7 +20,7 @@ jobs:
       - name: Running addons tests
         run: |
           set -x
-          sudo snap install microk8s --classic --channel=latest/edge
+          sudo snap install microk8s --classic --channel=1.35/edge
           sudo microk8s status --wait-ready --timeout 600
 
           if sudo microk8s addons repo list | grep community


### PR DESCRIPTION
#### chore: branch out 1.35

This PR branches out the 1.35 release for community addons.

Changes:
- CI workflows restricted to `pull_request:` on `1.35` branch
- Removed broad `push:` / `pull_request:` triggers
- Test job installs from `1.35/edge` snap channel

#### Checklist

* [x] Read the contributions page.
* [x] Submitted the CLA form.