### PR TITLE
feat(linkerd): bump to stable-2.14.10

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -43,7 +43,7 @@ microk8s-addons:
 
     - name: "linkerd"
       description: "Linkerd is a service mesh for Kubernetes and other frameworks"
-      version: "2.14.3"
+      version: "2.14.10"
       check_status: "pod/linkerd-destination"
       supported_architectures:
         - amd64

--- a/addons/linkerd/enable
+++ b/addons/linkerd/enable
@@ -11,7 +11,7 @@ ARCH=$(arch)
 
 # check if linkerd cli is already in the system.  Download if it doesn't exist.
 if [ ! -f "${SNAP_DATA}/bin/linkerd" ]; then
-  LINKERD_VERSION="${LINKERD_VERSION:-v2.14.3}"
+  LINKERD_VERSION="${LINKERD_VERSION:-v2.14.10}"
   echo "Fetching Linkerd2 version $LINKERD_VERSION."
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   LINKERD_VERSION=$(echo $LINKERD_VERSION | sed 's/v//g')


### PR DESCRIPTION
Bump Linkerd from v2.14.3 to v2.14.10 (patch release).

The enable script downloads the linkerd CLI binary — no manifest changes needed.

Changelog: https://github.com/linkerd/linkerd2/releases/tag/stable-2.14.10