### PR TITLE
feat(keda): bump to v2.17.3

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -102,7 +102,7 @@ microk8s-addons:
 
     - name: "keda"
       description: "Kubernetes-based Event Driven Autoscaling"
-      version: "2.12.0"
+      version: "2.17.3"
       check_status: "pod/keda-operator"
       supported_architectures:
         - amd64

--- a/addons/keda/enable
+++ b/addons/keda/enable
@@ -15,7 +15,7 @@ do_prerequisites() {
 
 
 get_keda () {
-  KEDA_VERSION="v2.12.0"
+  KEDA_VERSION="v2.17.3"
   KEDA_ERSION=$(echo $KEDA_VERSION | sed 's/v//g')
   echo "Fetching keda version $KEDA_ERSION."
   fetch_as https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_ERSION}.yaml "$SNAP_DATA/keda/keda.yaml"


### PR DESCRIPTION
Bump KEDA from v2.12.0 to v2.17.3.

The enable script downloads raw YAML manifests — no Helm chart or custom values at risk.

Changelogs: https://github.com/kedacore/keda/releases