### PR TITLE
feat(trivy): bump operator Helm chart to 0.24.1

### DIFF
--- a/addons/trivy/enable
+++ b/addons/trivy/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_TRIVY="trivy-system"
 
-TRIVY_HELM_VERSION="0.15.1"
+TRIVY_HELM_VERSION="0.24.1"
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 HELM="$SNAP/microk8s-helm3.wrapper"


### PR DESCRIPTION
Bump Trivy Operator Helm chart from 0.15.1 to 0.24.1.

Only custom value is `--set trivy.ignoreUnfixed=true` which is still supported.

Changelogs: https://github.com/aquasecurity/trivy-operator/releases