### PR TITLE
feat(nfs): bump server provisioner Helm chart to 1.8.0

### DIFF
--- a/addons/nfs/enable
+++ b/addons/nfs/enable
@@ -11,7 +11,7 @@ CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 NAMESPACE="nfs-server-provisioner"
 
-CHART_VERSION="1.4.0"
+CHART_VERSION="1.8.0"
 
 KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 "$SNAP/microk8s-enable.wrapper" helm3


### PR DESCRIPTION
Bump nfs-ganesha-server-and-external-provisioner Helm chart from 1.4.0 to 1.8.0.

Same major version (1.x). Custom values (persistence.enabled, persistence.storageClass, nodeSelector) are stable.

Changelogs: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/releases