### PR TITLE
feat(argocd): bump Helm chart to 7.9.1

### DIFF
--- a/addons/argocd/enable
+++ b/addons/argocd/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_ARGOCD="argocd"
 
-ARGOCD_HELM_VERSION="5.34.3"
+ARGOCD_HELM_VERSION="7.9.1"
 
 "$SNAP/microk8s-enable.wrapper" helm3
 


### PR DESCRIPTION
Bump ArgoCD Helm chart from 5.34.3 to 7.9.1.

No custom Helm values — the addon only passes `--version` and optional user-provided values file. Chart 5→7 is a bigger jump; watch CI.

Changelogs: https://github.com/argoproj/argo-helm/releases