### PR TITLE
fix: bump stunner-gateway-operator chart to 1.1.0

### DIFF
--- a/addons/stunner/enable
+++ b/addons/stunner/enable
@@ -7,7 +7,7 @@ set -e
 
 HELM="$SNAP/microk8s-helm3.wrapper"
 NAMESPACE_STUNNER_SYSTEM="stunner-system"
-VERSION_STUNNER_SYSTEM="0.18.0"
+VERSION_STUNNER_SYSTEM="1.1.0"
 
 echo "Enabling STUNner..."
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ import yaml
 import platform
 from subprocess import check_output, CalledProcessError, check_call
 
-
 arch_translate = {"aarch64": "arm64", "x86_64": "amd64"}
 
 


### PR DESCRIPTION
## Summary

The `test_stunner` CI job has been failing on `main` since April 2026, timing out after 600s waiting for the controller-manager pod to reach Running state.

## Root cause

The addon pins `stunner-gateway-operator` chart version `0.18.0` (released 2022). The upstream images referenced by this chart are no longer functional on current Kubernetes versions.

## Fix

- Bump `VERSION_STUNNER_SYSTEM` from `0.18.0` to `1.1.0` (May 2025, current stable release ([release notes](https://github.com/l7mp/stunner-gateway-operator/releases/tag/v1.1.0)))
- The pod label selector used by the test (`control-plane=stunner-gateway-operator-controller-manager`) is unchanged between chart versions — confirmed from the Helm chart templates

Also includes the `black` formatting fix for `tests/utils.py` (extra blank line between imports and first assignment) that is failing the Check Formatting CI step.