### PR TITLE
fix(stunner): skip gateway-api CRDs when already present in cluster

### DIFF
--- a/addons.yaml
+++ b/addons.yaml
@@ -229,7 +229,7 @@ microk8s-addons:
 
     - name: "stunner"
       description: "A Kubernetes media gateway for WebRTC"
-      version: "1.1.0"
+      version: "1.2.0"
       check_status: "deployment.apps/stunner-gateway-operator-controller-manager"
       supported_architectures:
         - arm64

--- a/addons/stunner/enable
+++ b/addons/stunner/enable
@@ -6,15 +6,32 @@ set -e
 "$SNAP/microk8s-enable.wrapper" helm3
 
 HELM="$SNAP/microk8s-helm3.wrapper"
+KUBECTL="$SNAP/microk8s-kubectl.wrapper"
 NAMESPACE_STUNNER_SYSTEM="stunner-system"
-VERSION_STUNNER_SYSTEM="1.1.0"
+VERSION_STUNNER_SYSTEM="1.2.0"
 
 echo "Enabling STUNner..."
 
 $HELM repo add stunner https://l7mp.io/stunner
 $HELM repo update
 
-$HELM upgrade --install stunner-gateway-operator stunner/stunner-gateway-operator \
-    --create-namespace --namespace $NAMESPACE_STUNNER_SYSTEM --version $VERSION_STUNNER_SYSTEM
+# Skip bundled Gateway API CRDs if they are already present in the cluster
+# (e.g. installed by the ingress addon). This avoids conflicts with the
+# ValidatingAdmissionPolicy introduced in Gateway API v1.5.x.
+SKIP_CRDS=""
+if $KUBECTL get crd gatewayclasses.gateway.networking.k8s.io > /dev/null 2>&1; then
+    echo "Gateway API CRDs already present, skipping bundled CRDs"
+    SKIP_CRDS="--skip-crds"
+
+    # Install STUNner's own CRDs manually since --skip-crds skips all CRDs
+    STUNNER_CRD_DIR=$(mktemp -d)
+    $HELM pull stunner/stunner --version $VERSION_STUNNER_SYSTEM --untar --untardir "$STUNNER_CRD_DIR"
+    $KUBECTL apply --server-side -f "$STUNNER_CRD_DIR/stunner/crds/stunner-crds.yaml"
+    rm -rf "$STUNNER_CRD_DIR"
+fi
+
+$HELM upgrade --install stunner-gateway-operator stunner/stunner \
+    --create-namespace --namespace $NAMESPACE_STUNNER_SYSTEM --version $VERSION_STUNNER_SYSTEM \
+    $SKIP_CRDS
 
 echo "STUNner is enabled."


### PR DESCRIPTION
## Problem

The ingress core addon (after canonical/microk8s-core-addons#396) installs Gateway API v1.5.1 which includes a `ValidatingAdmissionPolicy` (`safe-upgrades.gateway.networking.k8s.io`) that blocks CRD creation/update when the `bundle-version` annotation is < v1.5.0.

STUNner's Helm chart bundles gateway-api CRDs in its `crds/` directory. When users enable ingress first, then STUNner, the VAP blocks STUNner's CRD installation:

```
Error: failed to install CRD crds/gateway-api-crd.yaml: 8 errors occurred:
  * customresourcedefinitions.apiextensions.k8s.io "gatewayclasses.gateway.networking.k8s.io" is forbidden:
    ValidatingAdmissionPolicy 'safe-upgrades.gateway.networking.k8s.io' denied request:
    Installing CRDs with version before v1.5.0 is prohibited by default.
```

## Fix

- **Bump STUNner to v1.2.0** (chart renamed from `stunner-gateway-operator` to `stunner`)
- When gateway-api CRDs are already present in the cluster (from the ingress addon), use `--skip-crds` to avoid the VAP rejection
- Manually install only STUNner's own CRDs (`stunner-crds.yaml`) via `kubectl apply --server-side`, since `--skip-crds` skips *all* files in `crds/`
- The gateway-api CRDs from the ingress addon (v1.5.1) are fully backwards-compatible with what STUNner needs

### Why v1.2.0?

- v1.2.0 chart only contains `stunner-crds.yaml` in `crds/` (no longer bundles `gateway-api-crd.yaml`)
- v1.1.0 operator crashes at runtime because it requires `UDPRoute` v1alpha2 (experimental channel), which is not installed by the standard Gateway API CRDs

## Testing

Validated end-to-end on microk8s v1.32.13 (1.32/stable) with Gateway API v1.5.1 + VAP active:

```
=== Preconditions ===
$ kubectl get validatingadmissionpolicy safe-upgrades.gateway.networking.k8s.io
NAME                                      VALIDATIONS   PARAMKIND   AGE
safe-upgrades.gateway.networking.k8s.io   2             <unset>     15m

$ kubectl get crd gatewayclasses.gateway.networking.k8s.io -o jsonpath="{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}"
v1.5.1

=== Fix execution ===
$ helm pull stunner/stunner --version 1.2.0
$ ls crds/
stunner-crds.yaml    # <-- only STUNner CRDs, no gateway-api CRDs

$ kubectl apply --server-side -f stunner-crds.yaml
customresourcedefinition.apiextensions.k8s.io/gatewayconfigs.stunner.l7mp.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/staticservices.stunner.l7mp.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/dataplanes.stunner.l7mp.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/udproutes.stunner.l7mp.io serverside-applied

$ helm upgrade --install stunner-gateway-operator stunner/stunner \
    --create-namespace --namespace stunner-system --version 1.2.0 --skip-crds
STATUS: deployed

=== Post-install ===
$ kubectl get pods -n stunner-system
NAME                                                          READY   STATUS    RESTARTS   AGE
stunner-auth-55bc987c87-9x8wf                                 1/1     Running   0          30s
stunner-gateway-operator-controller-manager-d5fb84c47-grhlt   1/1     Running   0          30s

$ kubectl get validatingadmissionpolicy safe-upgrades.gateway.networking.k8s.io
NAME                                      VALIDATIONS   PARAMKIND   AGE
safe-upgrades.gateway.networking.k8s.io   2             <unset>     15m
# VAP still active, gateway-api CRDs still at v1.5.1 - untouched
```